### PR TITLE
Issue 8/move lower phase hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,11 @@ ENV/
 # PyCharm
 .idea
 
+# configs
+configs/
+
+# pki
+pki/
+
+# logs
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,10 @@ ENV/
 .idea
 
 # configs
-configs/
+configs/blockchain1.yml
+configs/blockchain2.yml
+configs/blockchain3.yml
+configs/blockchain4.yml
 
 # pki
 pki/

--- a/blockchain/gen/messaging/ttypes.py
+++ b/blockchain/gen/messaging/ttypes.py
@@ -1037,7 +1037,7 @@ class Node:
   def __ne__(self, other):
     return not (self == other)
 
-class VerificationRecordInfo:
+class VerificationRecordCommonInfo:
   """
   Attributes:
    - block_id
@@ -1046,6 +1046,7 @@ class VerificationRecordInfo:
    - verification_ts
    - signature
    - prior_hash
+   - lower_phase_hash
   """
 
   thrift_spec = (
@@ -1056,15 +1057,17 @@ class VerificationRecordInfo:
     (4, TType.I32, 'verification_ts', None, None, ), # 4
     (5, TType.STRUCT, 'signature', (Signature, Signature.thrift_spec), None, ), # 5
     (6, TType.STRING, 'prior_hash', None, None, ), # 6
+    (7, TType.STRING, 'lower_phase_hash', None, None, ), # 7
   )
 
-  def __init__(self, block_id=None, origin_id=None, phase=None, verification_ts=None, signature=None, prior_hash=None,):
+  def __init__(self, block_id=None, origin_id=None, phase=None, verification_ts=None, signature=None, prior_hash=None, lower_phase_hash=None,):
     self.block_id = block_id
     self.origin_id = origin_id
     self.phase = phase
     self.verification_ts = verification_ts
     self.signature = signature
     self.prior_hash = prior_hash
+    self.lower_phase_hash = lower_phase_hash
 
   def read(self, iprot):
     if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
@@ -1106,6 +1109,11 @@ class VerificationRecordInfo:
           self.prior_hash = iprot.readString()
         else:
           iprot.skip(ftype)
+      elif fid == 7:
+        if ftype == TType.STRING:
+          self.lower_phase_hash = iprot.readString()
+        else:
+          iprot.skip(ftype)
       else:
         iprot.skip(ftype)
       iprot.readFieldEnd()
@@ -1115,7 +1123,7 @@ class VerificationRecordInfo:
     if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
       oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
       return
-    oprot.writeStructBegin('VerificationRecordInfo')
+    oprot.writeStructBegin('VerificationRecordCommonInfo')
     if self.block_id is not None:
       oprot.writeFieldBegin('block_id', TType.I32, 1)
       oprot.writeI32(self.block_id)
@@ -1140,6 +1148,10 @@ class VerificationRecordInfo:
       oprot.writeFieldBegin('prior_hash', TType.STRING, 6)
       oprot.writeString(self.prior_hash)
       oprot.writeFieldEnd()
+    if self.lower_phase_hash is not None:
+      oprot.writeFieldBegin('lower_phase_hash', TType.STRING, 7)
+      oprot.writeString(self.lower_phase_hash)
+      oprot.writeFieldEnd()
     oprot.writeFieldStop()
     oprot.writeStructEnd()
 
@@ -1155,6 +1167,7 @@ class VerificationRecordInfo:
     value = (value * 31) ^ hash(self.verification_ts)
     value = (value * 31) ^ hash(self.signature)
     value = (value * 31) ^ hash(self.prior_hash)
+    value = (value * 31) ^ hash(self.lower_phase_hash)
     return value
 
   def __repr__(self):
@@ -1177,7 +1190,7 @@ class Phase_1_msg:
 
   thrift_spec = (
     None, # 0
-    (1, TType.STRUCT, 'record', (VerificationRecordInfo, VerificationRecordInfo.thrift_spec), None, ), # 1
+    (1, TType.STRUCT, 'record', (VerificationRecordCommonInfo, VerificationRecordCommonInfo.thrift_spec), None, ), # 1
     (2, TType.LIST, 'transactions', (TType.STRUCT,(Transaction, Transaction.thrift_spec)), None, ), # 2
   )
 
@@ -1196,7 +1209,7 @@ class Phase_1_msg:
         break
       if fid == 1:
         if ftype == TType.STRUCT:
-          self.record = VerificationRecordInfo()
+          self.record = VerificationRecordCommonInfo()
           self.record.read(iprot)
         else:
           iprot.skip(ftype)
@@ -1269,7 +1282,7 @@ class Phase_2_msg:
 
   thrift_spec = (
     None, # 0
-    (1, TType.STRUCT, 'record', (VerificationRecordInfo, VerificationRecordInfo.thrift_spec), None, ), # 1
+    (1, TType.STRUCT, 'record', (VerificationRecordCommonInfo, VerificationRecordCommonInfo.thrift_spec), None, ), # 1
     (2, TType.STRING, 'lower_phase_hash', None, None, ), # 2
     (3, TType.LIST, 'valid_txs', (TType.STRUCT,(Transaction, Transaction.thrift_spec)), None, ), # 3
     (4, TType.LIST, 'invalid_txs', (TType.STRUCT,(Transaction, Transaction.thrift_spec)), None, ), # 4
@@ -1296,7 +1309,7 @@ class Phase_2_msg:
         break
       if fid == 1:
         if ftype == TType.STRUCT:
-          self.record = VerificationRecordInfo()
+          self.record = VerificationRecordCommonInfo()
           self.record.read(iprot)
         else:
           iprot.skip(ftype)
@@ -1417,7 +1430,7 @@ class Phase_3_msg:
 
   thrift_spec = (
     None, # 0
-    (1, TType.STRUCT, 'record', (VerificationRecordInfo, VerificationRecordInfo.thrift_spec), None, ), # 1
+    (1, TType.STRUCT, 'record', (VerificationRecordCommonInfo, VerificationRecordCommonInfo.thrift_spec), None, ), # 1
     (2, TType.LIST, 'lower_phase_hashes', (TType.STRING,None), None, ), # 2
     (3, TType.I32, 'p2_count', None, None, ), # 3
     (4, TType.LIST, 'business_list', (TType.STRING,None), None, ), # 4
@@ -1442,7 +1455,7 @@ class Phase_3_msg:
         break
       if fid == 1:
         if ftype == TType.STRUCT:
-          self.record = VerificationRecordInfo()
+          self.record = VerificationRecordCommonInfo()
           self.record.read(iprot)
         else:
           iprot.skip(ftype)
@@ -1556,7 +1569,7 @@ class Phase_4_msg:
 
   thrift_spec = (
     None, # 0
-    (1, TType.STRUCT, 'record', (VerificationRecordInfo, VerificationRecordInfo.thrift_spec), None, ), # 1
+    (1, TType.STRUCT, 'record', (VerificationRecordCommonInfo, VerificationRecordCommonInfo.thrift_spec), None, ), # 1
     (2, TType.STRING, 'lower_phase_hash', None, None, ), # 2
   )
 
@@ -1575,7 +1588,7 @@ class Phase_4_msg:
         break
       if fid == 1:
         if ftype == TType.STRUCT:
-          self.record = VerificationRecordInfo()
+          self.record = VerificationRecordCommonInfo()
           self.record.read(iprot)
         else:
           iprot.skip(ftype)
@@ -1638,7 +1651,7 @@ class Phase_5_msg:
   thrift_spec = (
     None, # 0
     (1, TType.STRUCT, 'transaction', (Transaction, Transaction.thrift_spec), None, ), # 1
-    (2, TType.STRUCT, 'record', (VerificationRecordInfo, VerificationRecordInfo.thrift_spec), None, ), # 2
+    (2, TType.STRUCT, 'record', (VerificationRecordCommonInfo, VerificationRecordCommonInfo.thrift_spec), None, ), # 2
     (3, TType.STRING, 'hash', None, None, ), # 3
     (4, TType.STRING, 'misc', None, None, ), # 4
   )
@@ -1666,7 +1679,7 @@ class Phase_5_msg:
           iprot.skip(ftype)
       elif fid == 2:
         if ftype == TType.STRUCT:
-          self.record = VerificationRecordInfo()
+          self.record = VerificationRecordCommonInfo()
           self.record.read(iprot)
         else:
           iprot.skip(ftype)

--- a/blockchain/gen/messaging/ttypes.py
+++ b/blockchain/gen/messaging/ttypes.py
@@ -1273,7 +1273,6 @@ class Phase_2_msg:
   """
   Attributes:
    - record
-   - lower_phase_hash
    - valid_txs
    - invalid_txs
    - business
@@ -1283,16 +1282,14 @@ class Phase_2_msg:
   thrift_spec = (
     None, # 0
     (1, TType.STRUCT, 'record', (VerificationRecordCommonInfo, VerificationRecordCommonInfo.thrift_spec), None, ), # 1
-    (2, TType.STRING, 'lower_phase_hash', None, None, ), # 2
-    (3, TType.LIST, 'valid_txs', (TType.STRUCT,(Transaction, Transaction.thrift_spec)), None, ), # 3
-    (4, TType.LIST, 'invalid_txs', (TType.STRUCT,(Transaction, Transaction.thrift_spec)), None, ), # 4
-    (5, TType.STRING, 'business', None, None, ), # 5
-    (6, TType.STRING, 'deploy_location', None, None, ), # 6
+    (2, TType.LIST, 'valid_txs', (TType.STRUCT,(Transaction, Transaction.thrift_spec)), None, ), # 2
+    (3, TType.LIST, 'invalid_txs', (TType.STRUCT,(Transaction, Transaction.thrift_spec)), None, ), # 3
+    (4, TType.STRING, 'business', None, None, ), # 4
+    (5, TType.STRING, 'deploy_location', None, None, ), # 5
   )
 
-  def __init__(self, record=None, lower_phase_hash=None, valid_txs=None, invalid_txs=None, business=None, deploy_location=None,):
+  def __init__(self, record=None, valid_txs=None, invalid_txs=None, business=None, deploy_location=None,):
     self.record = record
-    self.lower_phase_hash = lower_phase_hash
     self.valid_txs = valid_txs
     self.invalid_txs = invalid_txs
     self.business = business
@@ -1314,11 +1311,6 @@ class Phase_2_msg:
         else:
           iprot.skip(ftype)
       elif fid == 2:
-        if ftype == TType.STRING:
-          self.lower_phase_hash = iprot.readString()
-        else:
-          iprot.skip(ftype)
-      elif fid == 3:
         if ftype == TType.LIST:
           self.valid_txs = []
           (_etype40, _size37) = iprot.readListBegin()
@@ -1329,7 +1321,7 @@ class Phase_2_msg:
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
-      elif fid == 4:
+      elif fid == 3:
         if ftype == TType.LIST:
           self.invalid_txs = []
           (_etype46, _size43) = iprot.readListBegin()
@@ -1340,12 +1332,12 @@ class Phase_2_msg:
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
-      elif fid == 5:
+      elif fid == 4:
         if ftype == TType.STRING:
           self.business = iprot.readString()
         else:
           iprot.skip(ftype)
-      elif fid == 6:
+      elif fid == 5:
         if ftype == TType.STRING:
           self.deploy_location = iprot.readString()
         else:
@@ -1364,30 +1356,26 @@ class Phase_2_msg:
       oprot.writeFieldBegin('record', TType.STRUCT, 1)
       self.record.write(oprot)
       oprot.writeFieldEnd()
-    if self.lower_phase_hash is not None:
-      oprot.writeFieldBegin('lower_phase_hash', TType.STRING, 2)
-      oprot.writeString(self.lower_phase_hash)
-      oprot.writeFieldEnd()
     if self.valid_txs is not None:
-      oprot.writeFieldBegin('valid_txs', TType.LIST, 3)
+      oprot.writeFieldBegin('valid_txs', TType.LIST, 2)
       oprot.writeListBegin(TType.STRUCT, len(self.valid_txs))
       for iter49 in self.valid_txs:
         iter49.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.invalid_txs is not None:
-      oprot.writeFieldBegin('invalid_txs', TType.LIST, 4)
+      oprot.writeFieldBegin('invalid_txs', TType.LIST, 3)
       oprot.writeListBegin(TType.STRUCT, len(self.invalid_txs))
       for iter50 in self.invalid_txs:
         iter50.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.business is not None:
-      oprot.writeFieldBegin('business', TType.STRING, 5)
+      oprot.writeFieldBegin('business', TType.STRING, 4)
       oprot.writeString(self.business)
       oprot.writeFieldEnd()
     if self.deploy_location is not None:
-      oprot.writeFieldBegin('deploy_location', TType.STRING, 6)
+      oprot.writeFieldBegin('deploy_location', TType.STRING, 5)
       oprot.writeString(self.deploy_location)
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -1400,7 +1388,6 @@ class Phase_2_msg:
   def __hash__(self):
     value = 17
     value = (value * 31) ^ hash(self.record)
-    value = (value * 31) ^ hash(self.lower_phase_hash)
     value = (value * 31) ^ hash(self.valid_txs)
     value = (value * 31) ^ hash(self.invalid_txs)
     value = (value * 31) ^ hash(self.business)
@@ -1564,18 +1551,15 @@ class Phase_4_msg:
   """
   Attributes:
    - record
-   - lower_phase_hash
   """
 
   thrift_spec = (
     None, # 0
     (1, TType.STRUCT, 'record', (VerificationRecordCommonInfo, VerificationRecordCommonInfo.thrift_spec), None, ), # 1
-    (2, TType.STRING, 'lower_phase_hash', None, None, ), # 2
   )
 
-  def __init__(self, record=None, lower_phase_hash=None,):
+  def __init__(self, record=None,):
     self.record = record
-    self.lower_phase_hash = lower_phase_hash
 
   def read(self, iprot):
     if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
@@ -1592,11 +1576,6 @@ class Phase_4_msg:
           self.record.read(iprot)
         else:
           iprot.skip(ftype)
-      elif fid == 2:
-        if ftype == TType.STRING:
-          self.lower_phase_hash = iprot.readString()
-        else:
-          iprot.skip(ftype)
       else:
         iprot.skip(ftype)
       iprot.readFieldEnd()
@@ -1611,10 +1590,6 @@ class Phase_4_msg:
       oprot.writeFieldBegin('record', TType.STRUCT, 1)
       self.record.write(oprot)
       oprot.writeFieldEnd()
-    if self.lower_phase_hash is not None:
-      oprot.writeFieldBegin('lower_phase_hash', TType.STRING, 2)
-      oprot.writeString(self.lower_phase_hash)
-      oprot.writeFieldEnd()
     oprot.writeFieldStop()
     oprot.writeStructEnd()
 
@@ -1625,7 +1600,6 @@ class Phase_4_msg:
   def __hash__(self):
     value = 17
     value = (value * 31) ^ hash(self.record)
-    value = (value * 31) ^ hash(self.lower_phase_hash)
     return value
 
   def __repr__(self):

--- a/blockchain/network.py
+++ b/blockchain/network.py
@@ -416,7 +416,6 @@ class ConnectionManager(object):
 
         phase_2_msg = message_types.Phase_2_msg()
         phase_2_msg.record = get_verification_record(verification_record)
-        phase_2_msg.lower_phase_hash = verification_info['lower_phase_hash']
         phase_2_msg.valid_txs = map(convert_to_thrift_transaction, verification_info['valid_txs'])
         phase_2_msg.invalid_txs = map(convert_to_thrift_transaction, verification_info['invalid_txs'])
         phase_2_msg.business = verification_info['business']
@@ -436,10 +435,10 @@ class ConnectionManager(object):
 
         phase_3_msg = message_types.Phase_3_msg()
         phase_3_msg.record = get_verification_record(verification_record)
-        phase_3_msg.lower_phase_hashes = verification_info['lower_phase_hashes']
         phase_3_msg.p2_count = verification_info['p2_count']
         phase_3_msg.business_list = verification_info['business_list']
         phase_3_msg.deploy_loc_list = verification_info['deploy_location_list']
+        phase_3_msg.lower_phase_hashes = verification_info['lower_phase_hashes']
 
         for node in self.peer_dict[phase_type]:
             try:

--- a/blockchain/processing.py
+++ b/blockchain/processing.py
@@ -29,13 +29,13 @@ __version__ = "2.0"
 __maintainer__ = "Joe Roets"
 __email__ = "joe@dragonchain.org"
 
-from blockchain.block import Block,               \
-                             BLOCK_FIXATE_OFFSET, \
-                             BLOCK_INTERVAL,      \
-                             get_block_time,      \
-                             get_current_block_id
+from blockchain.block import Block, \
+    BLOCK_FIXATE_OFFSET, \
+    BLOCK_INTERVAL, \
+    get_block_time, \
+    get_current_block_id
 
-from blockchain.util.crypto import valid_transaction_sig, sign_verification_record, validate_verification_record
+from blockchain.util.crypto import valid_transaction_sig, sign_verification_record, validate_verification_record, deep_hash
 
 from blockchain.util.thrift_conversions import thrift_record_to_dict, thrift_transaction_to_dict
 
@@ -99,6 +99,7 @@ class ProcessingNode(object):
             observer["callback"](config=observer["config"], **kwargs)
 
     """ INTERNAL METHODS """
+
     def _init_networking(self):
         """ currently only starts up network, may add more features """
         print 'initializing network'
@@ -250,9 +251,12 @@ class ProcessingNode(object):
             prior_block_hash = self.get_prior_hash(origin_id, phase)
             verification_info = approved_transactions
 
+            lower_phase_hash = str(deep_hash(0))
+
             # sign approved transactions
             block_info = sign_verification_record(signatory,
                                                   prior_block_hash,
+                                                  lower_phase_hash,
                                                   self.service_config['public_key'],
                                                   self.service_config['private_key'],
                                                   current_block_id,
@@ -307,17 +311,20 @@ class ProcessingNode(object):
 
             valid_transactions, invalid_transactions = self.check_tx_requirements(phase_1_info.transactions)
 
+            # TODO: take lower_phase_hash out of verification_info and have it hashed in sign_verification instead
             verification_info = {
-                                 'lower_phase_hash': phase_1_record['signature']['hash'],
-                                 'valid_txs': valid_transactions,
-                                 'invalid_txs': invalid_transactions,
-                                 'business': self.network.business,
-                                 'deploy_location': self.network.deploy_location
-                                }
+                'valid_txs': valid_transactions,
+                'invalid_txs': invalid_transactions,
+                'business': self.network.business,
+                'deploy_location': self.network.deploy_location
+            }
+
+            lower_phase_hash = phase_1_record['signature']['hash']
 
             # sign verification and rewrite record
             block_info = sign_verification_record(self.network.this_node.node_id,
                                                   prior_block_hash,
+                                                  lower_phase_hash,
                                                   self.service_config['public_key'],
                                                   self.service_config['private_key'],
                                                   phase_1_record['block_id'],
@@ -390,12 +397,11 @@ class ProcessingNode(object):
         prior_block_hash = self.get_prior_hash(phase_2_record['origin_id'], phase)
 
         p2_verification_info = {
-                             'lower_phase_hash': phase_2_info.lower_phase_hash,
-                             'valid_txs': map(thrift_transaction_to_dict, phase_2_info.valid_txs),
-                             'invalid_txs': map(thrift_transaction_to_dict, phase_2_info.invalid_txs),
-                             'business': phase_2_info.business,
-                             'deploy_location': phase_2_info.deploy_location
-                             }
+            'valid_txs': map(thrift_transaction_to_dict, phase_2_info.valid_txs),
+            'invalid_txs': map(thrift_transaction_to_dict, phase_2_info.invalid_txs),
+            'business': phase_2_info.business,
+            'deploy_location': phase_2_info.deploy_location
+        }
 
         if validate_verification_record(phase_2_info, p2_verification_info):
             # storing valid verification record
@@ -411,16 +417,22 @@ class ProcessingNode(object):
                 phase_2_record = thrift_record_to_dict(phase_2_info.record)
                 phase_2_record['phase'] = phase
 
+                lower_phase_hashes = [record['signature']['hash'] for record in phase_2_records]
+                # TODO: add a structure such as a tuple to pair signatory with it's appropriate hash (signatory, hash)
+                # TODO: and store that instead of lower_phase_hashes also add said structure to phase_3_msg in thrift
                 verification_info = {
-                                     'lower_phase_hashes': [record['signature']['hash'] for record in phase_2_records],
-                                     'p2_count': len(signatories),
-                                     'business_list': list(businesses),
-                                     'deploy_location_list': list(locations)
-                                    }
+                    'lower_phase_hashes': lower_phase_hashes,
+                    'p2_count': len(signatories),
+                    'business_list': list(businesses),
+                    'deploy_location_list': list(locations)
+                }
+
+                lower_phase_hash = str(deep_hash(lower_phase_hashes))
 
                 # sign verification and rewrite record
                 block_info = sign_verification_record(self.network.this_node.node_id,
                                                       prior_block_hash,
+                                                      lower_phase_hash,
                                                       self.service_config['public_key'],
                                                       self.service_config['private_key'],
                                                       phase_2_record['block_id'],
@@ -480,11 +492,11 @@ class ProcessingNode(object):
         phase_3_record = thrift_record_to_dict(phase_3_info.record)
 
         p3_verification_info = {
-                             'lower_phase_hashes': phase_3_info.lower_phase_hashes,
-                             'p2_count': phase_3_info.p2_count,
-                             'business_list': phase_3_info.business_list,
-                             'deploy_location_list': phase_3_info.deploy_loc_list
-                            }
+            'lower_phase_hashes': phase_3_info.lower_phase_hashes,
+            'p2_count': phase_3_info.p2_count,
+            'business_list': phase_3_info.business_list,
+            'deploy_location_list': phase_3_info.deploy_loc_list
+        }
 
         phase_3_record['verification_info'] = p3_verification_info
 
@@ -493,9 +505,12 @@ class ProcessingNode(object):
 
             phase_3_record['phase'] = phase
 
+            lower_phase_hash = phase_3_record['signature']['hash']
+
             # sign verification and rewrite record
             block_info = sign_verification_record(self.network.this_node.node_id,
                                                   prior_block_hash,
+                                                  lower_phase_hash,
                                                   self.service_config['public_key'],
                                                   self.service_config['private_key'],
                                                   phase_3_record['block_id'],
@@ -566,6 +581,7 @@ def main():
 
     finally:
         postgres.cleanup()
+
 
 # start calling f now and every 60 sec thereafter
 

--- a/blockchain/processing.py
+++ b/blockchain/processing.py
@@ -311,7 +311,6 @@ class ProcessingNode(object):
 
             valid_transactions, invalid_transactions = self.check_tx_requirements(phase_1_info.transactions)
 
-            # TODO: take lower_phase_hash out of verification_info and have it hashed in sign_verification instead
             verification_info = {
                 'valid_txs': valid_transactions,
                 'invalid_txs': invalid_transactions,

--- a/blockchain/util/crypto.py
+++ b/blockchain/util/crypto.py
@@ -113,6 +113,7 @@ def sign_transaction(signatory,
 
 def sign_verification_record(signatory,
                              prior_block_hash,
+                             lower_phase_hash,
                              public_key_string,
                              private_key_string,
                              block_id,
@@ -124,6 +125,7 @@ def sign_verification_record(signatory,
     sign verification record (common and special info among each phase)
     * signatory (current node's name/id)
     * prior_block_hash
+    * lower_phase_hash
     * public_key
     * private_key
     * block_id
@@ -139,13 +141,15 @@ def sign_verification_record(signatory,
     """
     # signature, transaction_hash = \
     #     sign_signatures(map(lambda tx: tx["signature"], approved_transactions), private_key_string)
+
     ecdsa_signing_key = SigningKey.from_pem(private_key_string)
     block_info = {}
     signature_ts = int(time.time())
     hashed_items = []
 
-    # append prior_block_hash
+    # append prior_block_hash and lower_phase_hash
     hashed_items.append(prior_block_hash)
+    hashed_items.append(lower_phase_hash)
 
     # append my signing info for hashing
     hashed_items.append(signatory)
@@ -172,6 +176,7 @@ def sign_verification_record(signatory,
         "origin_id": origin_id,
         "phase": int(phase),
         "prior_hash": prior_block_hash,
+        "lower_phase_hash": lower_phase_hash,
         "verification_info": verification_info  # special phase info
     }
 
@@ -273,6 +278,7 @@ def validate_verification_record(verification_record, verification_info, log=log
         validate_signature(signature_block)
 
         hashed_items.append(record['prior_hash'])
+        hashed_items.append(record['lower_phase_hash'])
 
         hashed_items.append(signature_block['signatory'])
         hashed_items.append(signature_block['signature_ts'])

--- a/blockchain/util/thrift_conversions.py
+++ b/blockchain/util/thrift_conversions.py
@@ -43,7 +43,8 @@ def thrift_record_to_dict(thrift_record):
         'phase': thrift_record.phase,
         'verification_ts': thrift_record.verification_ts,
         'signature': convert_thrift_signature(thrift_record.signature),
-        'prior_hash': thrift_record.prior_hash
+        'prior_hash': thrift_record.prior_hash,
+        'lower_phase_hash': thrift_record.lower_phase_hash
     }
 
 
@@ -139,11 +140,12 @@ def convert_to_thrift_signature(tx_signature):
 
 def get_verification_record(record):
     """ returns a thrift representation of a dictionary verification record """
-    thrift_record = message_types.VerificationRecordInfo()
+    thrift_record = message_types.VerificationRecordCommonInfo()
     thrift_record.block_id = record['block_id']
     thrift_record.origin_id = record['origin_id']
     thrift_record.phase = record['phase']
     thrift_record.verification_ts = record['verification_ts']
+    thrift_record.lower_phase_hash = record['lower_phase_hash']
 
     if record['prior_hash']:
         thrift_record.prior_hash = record['prior_hash']

--- a/scripts/valid_payload.json
+++ b/scripts/valid_payload.json
@@ -6,7 +6,7 @@
     "line_of_business": "My Business",
     "owner": "Test Node",
     "transaction_type": "TT_REQ",
-    "actor": "c26dd972-8683-11e6-977b-3c970e3bee11"
+    "actor": "c26dd972-8683-11e6-977b-3c970e3bee11",
     "entity": "c78f4526-8683-11e6-b1c6-3c970e3bee11"
   },
   "payload": {

--- a/thrift/messaging.thrift
+++ b/thrift/messaging.thrift
@@ -110,22 +110,23 @@ struct Node {
     5: i32 phases
 }
 
-struct VerificationRecordInfo {
+struct VerificationRecordCommonInfo {
     1: i32 block_id,
     2: string origin_id,
     3: i32 phase,
     4: i32 verification_ts,
     5: Signature signature,
-    6: string prior_hash
+    6: string prior_hash,
+    7: string lower_phase_hash
 }
 
 struct Phase_1_msg {
-    1: VerificationRecordInfo record,
+    1: VerificationRecordCommonInfo record,
     2: list<Transaction> transactions
 }
 
 struct Phase_2_msg {
-    1: VerificationRecordInfo record,
+    1: VerificationRecordCommonInfo record,
     2: string lower_phase_hash,
     3: list<Transaction> valid_txs,
     4: list<Transaction> invalid_txs,
@@ -133,9 +134,9 @@ struct Phase_2_msg {
     6: string deploy_location
 }
 
-/* rename business_list to businesses and deploy_loc_list to deploy_locations */
+/* TODO: rename business_list and deploy_loc_list to businesses and deploy_locations respectively */
 struct Phase_3_msg {
-    1: VerificationRecordInfo record,
+    1: VerificationRecordCommonInfo record,
     2: list<string> lower_phase_hashes,
     3: i32 p2_count,
     4: list<string> business_list,
@@ -143,13 +144,13 @@ struct Phase_3_msg {
 }
 
 struct Phase_4_msg {
-    1: VerificationRecordInfo record,
+    1: VerificationRecordCommonInfo record,
     2: string lower_phase_hash
 }
 
 union Phase_5_msg {
     1: Transaction transaction,
-    2: VerificationRecordInfo record,
+    2: VerificationRecordCommonInfo record,
     /* Level 5 node will NOT hash this field */
     3: string hash,
     /* Level 5 node WILL hash this field */

--- a/thrift/messaging.thrift
+++ b/thrift/messaging.thrift
@@ -127,11 +127,10 @@ struct Phase_1_msg {
 
 struct Phase_2_msg {
     1: VerificationRecordCommonInfo record,
-    2: string lower_phase_hash,
-    3: list<Transaction> valid_txs,
-    4: list<Transaction> invalid_txs,
-    5: string business,
-    6: string deploy_location
+    2: list<Transaction> valid_txs,
+    3: list<Transaction> invalid_txs,
+    4: string business,
+    5: string deploy_location
 }
 
 /* TODO: rename business_list and deploy_loc_list to businesses and deploy_locations respectively */
@@ -144,8 +143,7 @@ struct Phase_3_msg {
 }
 
 struct Phase_4_msg {
-    1: VerificationRecordCommonInfo record,
-    2: string lower_phase_hash
+    1: VerificationRecordCommonInfo record
 }
 
 union Phase_5_msg {


### PR DESCRIPTION
`lower_phase_hash` is now included as a top level parameter in `sign_verification_record`. Also being appended to hashed_items separately from `verification_info`.

`phase_1` lower phase hash is being set to 0 since there's not a phase lower than `phase_1`.
`phase_3`  is keeping the list of `phase_2` `lower_phase_hashes` in addition to creating a separate `lower_phase_hash` from the hash of `lower_phase_hashes`,  which is included as a top level parameter.
--Took note to consider storing a structure of (`signatory`, `hash`) rather than `lower_phase_hashes` in `phase_3`.

Ran and tested the code after making the changes through `phase_4` without issues.