### PR TITLE
partial work - bitcoin timestamping

### DIFF
--- a/blockchain/db/postgres/timestamp_db.py
+++ b/blockchain/db/postgres/timestamp_db.py
@@ -1,0 +1,96 @@
+"""
+Copyright 2016 Disney Connected and Advanced Technologies
+
+Licensed under the Apache License, Version 2.0 (the "Apache License")
+with the following modification; you may not use this file except in
+compliance with the Apache License and the following modification to it:
+Section 6. Trademarks. is deleted and replaced with:
+
+     6. Trademarks. This License does not grant permission to use the trade
+        names, trademarks, service marks, or product names of the Licensor
+        and its affiliates, except as required to comply with Section 4(c) of
+        the License and to reproduce the content of the NOTICE file.
+
+You may obtain a copy of the Apache License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the Apache License with the above modification is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the Apache License for the specific
+language governing permissions and limitations under the Apache License.
+"""
+
+__author__ = "Joe Roets, Brandon Kite, Dylan Yelton, Michael Bachtel"
+__copyright__ = "Copyright 2016, Disney Connected and Advanced Technologies"
+__license__ = "Apache"
+__version__ = "2.0"
+__maintainer__ = "Joe Roets"
+__email__ = "joe@dragonchain.org"
+
+import psycopg2
+import psycopg2.extras
+from psycopg2.extras import Json
+import uuid
+import time
+
+from blockchain.qry import format_block_verification
+from postgres import get_connection_pool
+
+""" CONSTANTS """
+DEFAULT_PAGE_SIZE = 256
+
+""" SQL QUERIES """
+SQL_GET_PENDING_QUERY = """SELECT * FROM timestamps WHERE timestamp_receipt IS NULL"""
+SQL_TIMESTAMP_QUERY   = """UPDATE timestamps SET timestamp_receipt = %s WHERE timestamp_id = %s"""
+
+SQL_INSERT_QUERY = """
+    INSERT INTO timestamps (
+        verification_id,
+        verified_ts,
+        block_id,
+        signature,
+        origin_id,
+        phase,
+        verification_info
+    ) VALUES (%s, to_timestamp(%s), %s, %s, %s, %s, %s)"""
+
+
+def get_cursor_name():
+    return str(uuid.uuid4())
+
+
+def set_transaction_timestamp_proof(verification_record):
+    values = (
+        verification_record['timestamp_id'],
+        verification_record['timestamp_receipt'],
+    )
+    conn = get_connection_pool().getconn()
+    try:
+        cur = conn.cursor()
+        cur.execute(SQL_TIMESTAMP_QUERY, values)
+        conn.commit()
+        cur.close()
+    finally:
+        get_connection_pool().putconn(conn)
+
+
+def insert_verification(verification_record):
+    values = (
+        str(uuid.uuid4()),
+        verification_record['verification_ts'],
+        verification_record["block_id"],
+        psycopg2.extras.Json(verification_record["signature"]),
+        verification_record["origin_id"],
+        verification_record["phase"],
+        psycopg2.extras.Json(verification_record["verification_info"])
+    )
+    conn = get_connection_pool().getconn()
+    try:
+        cur = conn.cursor()
+        cur.execute(SQL_INSERT_QUERY, values)
+        conn.commit()
+        cur.close()
+    finally:
+        get_connection_pool().putconn(conn)

--- a/blockchain/network.py
+++ b/blockchain/network.py
@@ -447,10 +447,22 @@ class ConnectionManager(object):
                 logger().warning('failed to submit to node %s', node.node_id)
                 continue
 
-    # TODO: implement this broadcast
+    # TODO: review this broadcast implementation
     def phase_4_broadcast(self, block_info, phase_type):
-        pass
+        """ send phase_4 information for phase_5 execution """
+        verification_record = block_info['verification_record']
+        verification_info = verification_record['verification_info']
 
+        phase_4_msg = message_types.Phase_4_msg()
+        phase_4_msg.record = get_verification_record(verification_record)
+        phase_4_msg.lower_phase_hashes = verification_info['lower_phase_hashes']
+
+        for node in self.peer_dict[phase_type]:
+            try:
+                node.client.phase_4_message(phase_4_msg)
+            except:
+                logger().warning('failed to submit to node %s', node.node_id)
+                continue
 
 class BlockchainServiceHandler:
     def __init__(self, connection_manager):

--- a/blockchain/processing.py
+++ b/blockchain/processing.py
@@ -41,6 +41,7 @@ from blockchain.util.thrift_conversions import thrift_record_to_dict, thrift_tra
 
 from db.postgres import transaction_db
 from db.postgres import verfication_db
+from db.postgres import timestamp_db
 from db.postgres import postgres
 
 import network
@@ -48,9 +49,13 @@ import network
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 
+from merkleproof import MerkleTree
+from blockchain.timestamping import BitcoinTimestamper, BitcoinFeeProvider
+
 import logging
 import argparse
 import time
+import hashlib
 
 # TODO increase these for network sizing and later deliver via blockchain
 P2_COUNT_REQ = 1
@@ -148,6 +153,17 @@ class ProcessingNode(object):
 
         elif config["phase"] == 5:
             self._add_registration(5, self._execute_phase_5, config)
+            self._add_registration("timestamp", self._execute_timestamping, config)
+
+            # Setup phase 5 cron
+            trigger = CronTrigger(second='*/30')
+
+            # setup the scheduler task
+            def trigger_handler():
+                self.notify(event_name="timestamp")
+
+            # schedule task using cron trigger
+            self._scheduler.add_job(trigger_handler, trigger)
 
     def _cron_type_config_handler(self, config):
         """
@@ -525,7 +541,39 @@ class ProcessingNode(object):
 
     def _execute_phase_5(self, config, phase_4_info):
         """ public, Bitcoin bridge phase """
+        phase = 5
+        phase_4_record = thrift_record_to_dict(phase_4_info.record)
+
+        p4_verification_info = {
+            'lower_phase_hashes': phase_4_info.lower_phase_hashes,
+        }
+
+        phase_4_record['verification_info'] = p4_verification_info
+
+        valid_record = validate_verification_record(phase_4_info, p4_verification_info)
+        if not valid_record:
+            return
+
+        timestamp_db.insert_verification(phase_4_record)
         print "phase 5 executed"
+
+    def _execute_timestamping(self, config):
+        pending_records = timestamp_db.get_pending_timestamp()
+
+        pending_records_hash = [hashlib.sha256(r).hexdigest() for r in pending_records]
+        merkle_tree = MerkleTree()
+        merkle_tree.add_leaves(pending_records_hash)
+        merkle_tree.make_tree()
+
+        merkle_root = merkle_tree.get_merkle_root()
+        stamper = BitcoinTimestamper(self.service_config['bitcoin_network'], BitcoinFeeProvider())
+        bitcoin_tx_id = stamper.persist(merkle_root)
+
+        for index, pr in pending_records:
+            receipt = merkle_tree.make_receipt(index, bitcoin_tx_id)
+            pr["timestamp_receipt"] = receipt
+            timestamp_db.set_transaction_timestamp_proof(pr)
+
 
     @staticmethod
     def split_items(filter_func, items):
@@ -549,6 +597,7 @@ def main():
         parser.add_argument('--debug', default=True, action="store_true")
         parser.add_argument('--private-key', dest="private_key", required=True, help="ECDSA private key for signing")
         parser.add_argument('--public-key', dest="public_key", required=True, help="ECDSA public key for signing")
+        parser.add_argument('--bitcoin-network', dest="bitcoin_network", required=False, help="Bitcoin network (mainnet, testnet, regtest)")
 
         logger().info("Parsing arguments")
         args = vars(parser.parse_args())
@@ -566,6 +615,7 @@ def main():
         host = args["host"]
         port = args["port"]
         phase = args["phase"]
+        bitcoin_network = args["bitcoin_network"]
 
         ProcessingNode([{
             "type": "phase",
@@ -575,7 +625,8 @@ def main():
             "public_key": public_key,
             "owner": "DTSS",
             "host": host,
-            "port": port
+            "port": port,
+            "bitcoin_network": bitcoin_network
         }).start()
 
     finally:

--- a/blockchain/timestamping.py
+++ b/blockchain/timestamping.py
@@ -1,0 +1,205 @@
+"""
+Copyright 2016 Disney Connected and Advanced Technologies
+
+Licensed under the Apache License, Version 2.0 (the "Apache License")
+with the following modification; you may not use this file except in
+compliance with the Apache License and the following modification to it:
+Section 6. Trademarks. is deleted and replaced with:
+
+     6. Trademarks. This License does not grant permission to use the trade
+        names, trademarks, service marks, or product names of the Licensor
+        and its affiliates, except as required to comply with Section 4(c) of
+        the License and to reproduce the content of the NOTICE file.
+
+You may obtain a copy of the Apache License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the Apache License with the above modification is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the Apache License for the specific
+language governing permissions and limitations under the Apache License.
+"""
+
+__author__ = "Joe Roets, Brandon Kite, Dylan Yelton, Michael Bachtel"
+__copyright__ = "Copyright 2016, Disney Connected and Advanced Technologies"
+__license__ = "Apache"
+__version__ = "2.0"
+__maintainer__ = "Joe Roets"
+__email__ = "joe@dragonchain.org"
+
+
+"""
+Module for storing data into the bitcoin blockchain transaction ontput scripts
+"""
+
+import bitcoin.rpc
+
+from bitcoin import params
+from bitcoin.core import *
+from bitcoin.core.script import *
+
+import requests
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class IPoEStore(object):
+    """
+    Abstracts a proof-of-existence store.
+    """
+
+    def ispersisted(self, id, data):
+        """
+        Verifies ``data`` item is persisted on the datastore with identifier ``id``
+        Args:
+            id: the data item identifier within the datastore
+            data: the item data we want to verify
+
+        Returns:
+            True if the ``data`` item is in the datastore with identifier ``id``; otherwise False
+        """
+        pass
+
+    def persist(self, data):
+        """
+        Persists data in a datastore and returns and identifier for future reference
+        Args:
+            data:   the item data to be persisted
+
+        Returns:
+            An identifier for referencing the saved data item:
+        """
+        pass
+
+
+class BitcoinTimestamper(IPoEStore):
+    """
+    Stamps a data item in the bitcoin blockchain and also allows us to verifies the
+    existence of a data item in a given bitcoin transaction output. For doing this
+    a bitcoin node is required and available through RPC. The access data such as
+    user name and password are read from ~/.bitcoin/bitcoin.conf configuration file
+
+    usage example:
+        fee_provider = BitcoinFeeProvider()
+        stamper = BitcoinTimestamper("regtest", fee_provider)
+        txid = stamper.persist("hello world!")
+        assert stamper.ispersisted(txid, "hello world!"), "data item not present in the given txid"
+    """
+    MIN_FEE_BYTE = 60
+
+    def __init__(self, network, fee_provider):
+        """
+        Initializes a instance for working against a bitcoin network.
+        Args:
+            network: mainnet, regtest, testnet
+            fee_provider: suggests fee per bytes to pay
+        """
+        bitcoin.SelectParams(network)
+        self.fee_provider = fee_provider
+
+    def ispersisted(self, tx_id, data):
+        """
+        Verifies ``data`` item is on the bitcoin transaction identified by the ``tx_id``
+        Args:
+            tx_id: the bitcoin transaction id where the data is stored
+            data: the item data we want to verify
+
+        Returns:
+            True if the ``data`` item is in the bitcoin transaction identified by ``tx_id``; otherwise False
+        """
+        log.info('Connection to local bitcoin node')
+        proxy = bitcoin.rpc.Proxy()
+        tx = proxy.getrawtransaction(tx_id, True)['tx']
+        for vout in tx.vout:
+            step = 'init'
+            for op in vout.scriptPubKey:
+                if step == 'init' and op == OP_RETURN:
+                    step = 'waiting_data'
+                    continue
+                if step == 'waiting_data' and op == data:
+                    return True
+        return False
+
+    def persist(self, data):
+        """
+        Persists data in the Bitcoin blockchain and returns and transaction id for future reference.
+
+        Connects to the local bitcoin node using the bitcoin.conf file RPC username and password,
+        requests the list of unspent transaction outputs (UTXO) and takes the one with less amount
+        from being used as input in the new transaction.
+
+
+        Args:
+            data: the item data to be persisted
+
+        Returns:
+            A transaction id for referencing the saved data item in the transaction output
+        """
+        proxy = bitcoin.rpc.Proxy()
+        utxo = sorted(proxy.listunspent(0), key=lambda x: hash(x['amount']))[-1]
+        tx = self._build_transaction(utxo, self.get_new_pubkey(), data)
+        value_in = utxo['amount']
+
+        fee_byte = self.fee_provider.recommended()
+        fee_byte = max(fee_byte, self.MIN_FEE_BYTE)
+        assert fee_byte < self.MAX_FEE_BYTE, "too high fee"
+
+        while True:
+            suggested_fee = len(tx.serialize()) * fee_byte
+            tx.vout[0].nValue = int(value_in - suggested_fee)
+            r = proxy.signrawtransaction(tx)
+            assert r['complete']
+            tx = r['tx']
+            effective_fee = value_in - tx.vout[0].nValue
+            suggested_fee = len(tx.serialize()) * fee_byte
+            if effective_fee >= suggested_fee:
+                tx = proxy.sendrawtransaction(tx)
+                break
+        return tx
+
+    def get_new_pubkey(self):
+        """
+        Requests a new bitcoin address and returns its public key
+        """
+        proxy = bitcoin.rpc.Proxy()
+        address = proxy.getnewaddress()
+        pubkey = proxy.validateaddress(address)['pubkey']
+        return pubkey
+
+    def _build_transaction(self, output, change_pubkey, data):
+        """
+        Builds a bitcoin transaction with 1 input an 2 outputs:
+            output 1 - the change output
+            output 2 - the OP_RETURN + data output
+        Args:
+            output: the coin to use as input
+            change_pubkey: change address' pubkey
+            data: data item (a hash) to persist after the OP_RETURN opcode
+        Returns:
+            a bitcoin transaction that is candidate for being broadcasted to the network
+        """
+        txins = [CTxIn(output)]
+        change_out = CMutableTxOut(params.MAX_MONEY, CScript([change_pubkey, OP_CHECKSIG]))
+        digest_out = CMutableTxOut(0, CScript([OP_RETURN, data]))
+        tx = CMutableTransaction(txins, [change_out, digest_out])
+        return tx
+
+
+class BitcoinFeeProvider(object):
+    """
+    Provides estimated bitcoin fee using a 3rd party service.
+    """
+    def recommended(self):
+        """
+        provides an recommended fee per byte
+
+        Return: the avg value between the estimated fastestFee value and the estimated
+        halfHourFee value.
+        """
+        response = requests.get("https://bitcoinfees.21.co/api/v1/fees/recommended")
+        fees = response.json()
+        calculated_fee = 0.5 * (int(fees["fastestFee"]) + int(fees["halfHourFee"]))
+        return int(calculated_fee)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,7 @@ thrift==0.9.3
 pytest==2.8.0
 rx==1.2.3
 pyyaml==3.11
+python-bitcoinlib==0.6.1
+merkle-proofs==0.0.6
+requests==2.11.1
 -e .

--- a/sql/timestamp.sql
+++ b/sql/timestamp.sql
@@ -31,7 +31,29 @@ __email__ = "joe@dragonchain.org"
 
 */
 
-\i types.sql
-\i txpool.sql
-\i net.sql
-\i timestamp.sql
+
+BEGIN;
+/* Don't drop tables unless you really want to */
+--DROP TABLE transactions;
+CREATE TABLE IF NOT EXISTS timestamps (
+
+    timestamp_id UUID PRIMARY KEY,
+
+    block_id INT,
+
+    /* confirm: when the transaction record was created */
+    create_ts timestamptz,
+
+    /* chainpoint receipt containing the required data for verifying the timestamp */
+    timestamp_receipt JSON
+
+    /* Signature block - includes public key */
+    signature JSON,
+
+    /* arbitrary info per phase */
+    verification_info JSON,
+);
+COMMIT;
+BEGIN;
+GRANT ALL ON timestamps to blocky;
+COMMIT;


### PR DESCRIPTION
This is the **unfinished-and-untested** bitcoin timestamping feature. 

What's done and what is not:
- `blockchain/timestamping.py` contains the _bitcoin timestamper_ that uses a local bitcoin node for managing the wallet (`getting utxos`, `getting new addresses`, `signing transactions`, etc), broadcasting transactions, querying transactions and tx outputs. It also contains an estimated fee provider that uses a 3rd party service for getting real-time estimated fee required for miners to include our tx in next block. All **what is in this file is tested**. This was tested with the `regtest` bitcoin network and also with the broadcasted transaction mined (in a block) as well as the transaction in the mempool.
- `blockchain/processing.py` was modified in order to implement phase 5 that receives a phase 4 message, verifies it and persists it as "pending for timestamping". There is a `cron` configured for running _every 30 seconds_ that performs a query against the db to get all the _"pending for timestamping" records_, builds the merkletree with those and timestamps the merkle tree root hash in the bitcoin blockchain. After that it updates all the records with the chainpoint proof receipt. So, nodes can verify the proof of existence for any record using the `BitcoinTimestamper` class.  This is not tested and it is not validated for correctness.
- The rest is probably not okay (or simply wrong), incomplete and untested.
