### PR TITLE
issue-34/isolate thrift dependencies

### DIFF
--- a/blockchain/network.py
+++ b/blockchain/network.py
@@ -539,7 +539,16 @@ class BlockchainServiceHandler:
         self.connection_manager.processing_node.notify(3, phase_2_info=phase_2_info)
 
     def phase_3_message(self, phase_3):
-        self.connection_manager.processing_node.notify(4, phase_3_info=phase_3)
+        phase_3_info = {
+            'record': thrift_record_to_dict(phase_3.record),
+            'verification_info': {
+                'lower_phase_hashes': phase_3.lower_phase_hashes,
+                'p2_count': phase_3.p2_count,
+                'business_list': phase_3.business_list,
+                'deploy_location_list': phase_3.deploy_loc_list
+            }
+        }
+        self.connection_manager.processing_node.notify(4, phase_3_info=phase_3_info)
 
     def phase_4_message(self, phase_4):
         self.connection_manager.processing_node.notify(5, phase_4_info=phase_4)

--- a/blockchain/network.py
+++ b/blockchain/network.py
@@ -46,7 +46,10 @@ from blockchain.db.postgres import network_db as net_dao
 import gen.messaging.BlockchainService as BlockchainService
 import gen.messaging.ttypes as message_types
 
-from blockchain.util.thrift_conversions import convert_to_thrift_transaction, get_verification_record
+from blockchain.util.thrift_conversions import convert_to_thrift_transaction, \
+                                               get_verification_record, \
+                                               thrift_record_to_dict, \
+                                               thrift_transaction_to_dict
 
 from thrift import Thrift
 from thrift.transport import TSocket
@@ -335,7 +338,6 @@ class ConnectionManager(object):
                     # peer.connection_attempts < MAX_CONNECTION_ATTEMPTS and \
                     # len(self.peers) < self.max_outbound_connections:
                     logger().info('attempting connect_thrift_node %s:%s', node_to_connect.host, node_to_connect.port)
-                    # self.peers.append(peer)
 
                     pass_phrase = str(uuid.uuid4())
 
@@ -518,7 +520,11 @@ class BlockchainServiceHandler:
 
     def phase_1_message(self, phase_1):
         """ submit phase_1 block for phase_2 validation_phase """
-        self.connection_manager.processing_node.notify(2, phase_1_info=phase_1)
+        phase_1_info = {
+            'record': thrift_record_to_dict(phase_1.record),
+            'verification_info': map(thrift_transaction_to_dict, phase_1.transactions)
+        }
+        self.connection_manager.processing_node.notify(2, phase_1_info=phase_1_info)
 
     def phase_2_message(self, phase_2):
         self.connection_manager.processing_node.notify(3, phase_2_info=phase_2)

--- a/blockchain/network.py
+++ b/blockchain/network.py
@@ -527,7 +527,16 @@ class BlockchainServiceHandler:
         self.connection_manager.processing_node.notify(2, phase_1_info=phase_1_info)
 
     def phase_2_message(self, phase_2):
-        self.connection_manager.processing_node.notify(3, phase_2_info=phase_2)
+        phase_2_info = {
+            'record': thrift_record_to_dict(phase_2.record),
+            'verification_info': {
+                'valid_txs': map(thrift_transaction_to_dict, phase_2.valid_txs),
+                'invalid_txs': map(thrift_transaction_to_dict, phase_2.invalid_txs),
+                'business': phase_2.business,
+                'deploy_location': phase_2.deploy_location
+            }
+        }
+        self.connection_manager.processing_node.notify(3, phase_2_info=phase_2_info)
 
     def phase_3_message(self, phase_3):
         self.connection_manager.processing_node.notify(4, phase_3_info=phase_3)

--- a/blockchain/processing.py
+++ b/blockchain/processing.py
@@ -395,6 +395,7 @@ class ProcessingNode(object):
         phase_2_record['verification_info'] = p2_verification_info
         prior_block_hash = self.get_prior_hash(phase_2_record['origin_id'], phase)
 
+        # validate phase_2's verification record
         if validate_verification_record(phase_2_record, p2_verification_info):
             # storing valid verification record
             verfication_db.insert_verification(phase_2_record)
@@ -484,6 +485,7 @@ class ProcessingNode(object):
         phase_3_record['verification_info'] = p3_verification_info
         prior_block_hash = self.get_prior_hash(phase_3_record['origin_id'], phase)
 
+        # validate phase_3's verification record
         if validate_verification_record(phase_3_record, p3_verification_info):
             # storing valid verification record
             verfication_db.insert_verification(phase_3_record)

--- a/blockchain/processing.py
+++ b/blockchain/processing.py
@@ -296,7 +296,6 @@ class ProcessingNode(object):
           - tx minus the payload
         """
         phase = 2
-        # prior_block_hash = self.get_prior_hash(phase_1_info.record.origin_id, phase)
         phase_1_record = phase_1_info["record"]
         p1_verification_info = phase_1_info["verification_info"]
         phase_1_record['verification_info'] = p1_verification_info
@@ -335,7 +334,7 @@ class ProcessingNode(object):
                                                   )
 
             # inserting verification info after signing
-            verfication_db.insert_verification(block_info['verification_record'])  # commented out so we don't continuously add same block
+            verfication_db.insert_verification(block_info['verification_record'])
             self.network.send_block(self.network.phase_2_broadcast, block_info, phase_1_record['phase'])
 
             print "phase_2 executed"
@@ -508,7 +507,7 @@ class ProcessingNode(object):
                                                   )
 
             # inserting verification info after signing
-            verfication_db.insert_verification(block_info['verification_record'])  # commented out so we don't continuously add same block
+            verfication_db.insert_verification(block_info['verification_record'])
             self.network.send_block(self.network.phase_4_broadcast, block_info, phase)
             print "phase 4 executed"
 

--- a/blockchain/util/crypto.py
+++ b/blockchain/util/crypto.py
@@ -267,7 +267,7 @@ def validate_signature(signature_block, log=logging.getLogger(__name__)):
         verifying_key.verify(decoded_digest, str(signature_block["hash"]))
 
 
-def validate_verification_record(verification_record, verification_info, log=logging.getLogger(__name__)):
+def validate_verification_record(record, verification_info, log=logging.getLogger(__name__)):
     """
     validate verification record signature
     * verification_record - general info per phase - signing name, timestamp, pub_key, block_id, etc.
@@ -275,7 +275,6 @@ def validate_verification_record(verification_record, verification_info, log=log
     """
     hashed_items = []
     try:
-        record = thrift_record_to_dict(verification_record.record)
         signature_block = record['signature']
 
         validate_signature(signature_block)


### PR DESCRIPTION
All thrift conversions are now being done in network.py. Ran and tested up to phase 4 without issues.

May have to relook at issue-37 (refactoring lower_phase_hash) due to code being moved around.