### PR TITLE
Issue 28/query criteria

### DIFF
--- a/blockchain/db/postgres/transaction_db.py
+++ b/blockchain/db/postgres/transaction_db.py
@@ -44,6 +44,7 @@ from postgres import get_connection_pool
 DEFAULT_PAGE_SIZE = 1000
 """ SQL Queries """
 SQL_GET_BY_ID = """SELECT * FROM transactions WHERE transaction_id = %s"""
+# adding to test querying anything
 SQL_GET_ALL = """SELECT * FROM transactions"""
 SQL_INSERT = """INSERT into transactions (
                             transaction_id,
@@ -98,6 +99,35 @@ def get_all(limit=None, offset=None, **params):
         query += """ transaction_type = '""" + str(params["transaction_type"]) + """'"""
         multi_param = True
 
+    if "business_unit" in params:
+        if multi_param:
+            query += """ AND """
+        query += """ business_unit = '""" + str(params["business_unit"]) + """'"""
+        multi_param = True
+
+    if "family_of_business" in params:
+        if multi_param:
+            query += """ AND """
+        query+= """ family_of_business = '""" + str(params["family_of_business"]) + """'"""
+
+    if "line_of_business" in params:
+        if multi_param:
+            query += """ AND """
+        query += """ line_of_business = '""" + str(params["line_of_business"]) + """'"""
+        multi_param = True
+
+    if "signature" in params:
+        if multi_param:
+            query += """ AND """
+        query += """ signature = '""" + str(params["signature"]) + """'"""
+        multi_param = True
+
+    if "status" in params:
+        if multi_param:
+            query += """ AND """
+        query += """ status = '""" + str(params["status"]) + """'"""
+        multi_param = True
+
     if "owner" in params:
         if multi_param:
             query += """ AND """
@@ -115,10 +145,30 @@ def get_all(limit=None, offset=None, **params):
             query += """ AND """
         query += """ entity = '""" + str(params["entity"]) + """'"""
         multi_param = True
+
+    if "create_ts" in params:
+        if multi_param:
+            query += """ AND """
+        if '-' in params["create_ts"]:
+            # if it is timestamp >= UNIX-epoch timecode
+            if params["create_ts"].index('-') == 0:
+                start_time = time.strftime('%Y-%m-%d %H:%M:%S',time.gmtime(float(params["create_ts"][1:])))
+                query += """ create_ts >= '""" + start_time + """'"""
+            elif params["create_ts"].endswith('-'):
+                end_time = time.strftime('%Y-%m-%d %H:%M:%S',time.gmtime(float(params["create_ts"][:len(params["create_ts"])-1])))
+                query += """ create_ts <= '""" + end_time + """'"""
+            else:
+                start_time = time.strftime('%Y-%m-%d %H:%M:%S',time.gmtime(float(params["create_ts"][:params["create_ts"].index('-')])))
+                end_time = time.strftime('%Y-%m-%d %H:%M:%S',  time.gmtime(float(params["create_ts"][params["create_ts"].index('-')+1:])))
+                query += """ create_ts >= '""" + start_time + """' AND create_ts <= '""" + end_time + """'"""
+        else:
+            cur_time = time.strftime('%Y-%m-%d %H:%M:%S',  time.gmtime(float(params["create_ts"])))
+            query += """ create_ts = '""" + cur_time + '-07'"""'"""
+        multi_param = True
         # not used but left in place to handle future params
 
     query += """ ORDER BY transaction_ts DESC """
-
+    print(query)
     if not limit:
         limit = 10
 

--- a/blockchain/gen/messaging/ttypes.py
+++ b/blockchain/gen/messaging/ttypes.py
@@ -1409,7 +1409,7 @@ class Phase_3_msg:
   """
   Attributes:
    - record
-   - lower_hash
+   - lower_hashes
    - p2_count
    - business_list
    - deploy_loc_list
@@ -1418,15 +1418,15 @@ class Phase_3_msg:
   thrift_spec = (
     None, # 0
     (1, TType.STRUCT, 'record', (VerificationRecordCommonInfo, VerificationRecordCommonInfo.thrift_spec), None, ), # 1
-    (2, TType.LIST, 'lower_hash', (TType.STRING,None), None, ), # 2
+    (2, TType.LIST, 'lower_hashes', (TType.STRING,None), None, ), # 2
     (3, TType.I32, 'p2_count', None, None, ), # 3
     (4, TType.LIST, 'business_list', (TType.STRING,None), None, ), # 4
     (5, TType.LIST, 'deploy_loc_list', (TType.STRING,None), None, ), # 5
   )
 
-  def __init__(self, record=None, lower_hash=None, p2_count=None, business_list=None, deploy_loc_list=None,):
+  def __init__(self, record=None, lower_hashes=None, p2_count=None, business_list=None, deploy_loc_list=None,):
     self.record = record
-    self.lower_hash = lower_hash
+    self.lower_hashes = lower_hashes
     self.p2_count = p2_count
     self.business_list = business_list
     self.deploy_loc_list = deploy_loc_list
@@ -1448,11 +1448,11 @@ class Phase_3_msg:
           iprot.skip(ftype)
       elif fid == 2:
         if ftype == TType.LIST:
-          self.lower_hash = []
+          self.lower_hashes = []
           (_etype54, _size51) = iprot.readListBegin()
           for _i55 in xrange(_size51):
             _elem56 = iprot.readString()
-            self.lower_hash.append(_elem56)
+            self.lower_hashes.append(_elem56)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -1495,10 +1495,10 @@ class Phase_3_msg:
       oprot.writeFieldBegin('record', TType.STRUCT, 1)
       self.record.write(oprot)
       oprot.writeFieldEnd()
-    if self.lower_hash is not None:
-      oprot.writeFieldBegin('lower_hash', TType.LIST, 2)
-      oprot.writeListBegin(TType.STRING, len(self.lower_hash))
-      for iter69 in self.lower_hash:
+    if self.lower_hashes is not None:
+      oprot.writeFieldBegin('lower_hashes', TType.LIST, 2)
+      oprot.writeListBegin(TType.STRING, len(self.lower_hashes))
+      for iter69 in self.lower_hashes:
         oprot.writeString(iter69)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
@@ -1530,7 +1530,7 @@ class Phase_3_msg:
   def __hash__(self):
     value = 17
     value = (value * 31) ^ hash(self.record)
-    value = (value * 31) ^ hash(self.lower_hash)
+    value = (value * 31) ^ hash(self.lower_hashes)
     value = (value * 31) ^ hash(self.p2_count)
     value = (value * 31) ^ hash(self.business_list)
     value = (value * 31) ^ hash(self.deploy_loc_list)

--- a/blockchain/gen/messaging/ttypes.py
+++ b/blockchain/gen/messaging/ttypes.py
@@ -1046,7 +1046,7 @@ class VerificationRecordCommonInfo:
    - verification_ts
    - signature
    - prior_hash
-   - lower_phase_hash
+   - lower_hash
   """
 
   thrift_spec = (
@@ -1057,17 +1057,17 @@ class VerificationRecordCommonInfo:
     (4, TType.I32, 'verification_ts', None, None, ), # 4
     (5, TType.STRUCT, 'signature', (Signature, Signature.thrift_spec), None, ), # 5
     (6, TType.STRING, 'prior_hash', None, None, ), # 6
-    (7, TType.STRING, 'lower_phase_hash', None, None, ), # 7
+    (7, TType.STRING, 'lower_hash', None, None, ), # 7
   )
 
-  def __init__(self, block_id=None, origin_id=None, phase=None, verification_ts=None, signature=None, prior_hash=None, lower_phase_hash=None,):
+  def __init__(self, block_id=None, origin_id=None, phase=None, verification_ts=None, signature=None, prior_hash=None, lower_hash=None,):
     self.block_id = block_id
     self.origin_id = origin_id
     self.phase = phase
     self.verification_ts = verification_ts
     self.signature = signature
     self.prior_hash = prior_hash
-    self.lower_phase_hash = lower_phase_hash
+    self.lower_hash = lower_hash
 
   def read(self, iprot):
     if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
@@ -1111,7 +1111,7 @@ class VerificationRecordCommonInfo:
           iprot.skip(ftype)
       elif fid == 7:
         if ftype == TType.STRING:
-          self.lower_phase_hash = iprot.readString()
+          self.lower_hash = iprot.readString()
         else:
           iprot.skip(ftype)
       else:
@@ -1148,9 +1148,9 @@ class VerificationRecordCommonInfo:
       oprot.writeFieldBegin('prior_hash', TType.STRING, 6)
       oprot.writeString(self.prior_hash)
       oprot.writeFieldEnd()
-    if self.lower_phase_hash is not None:
-      oprot.writeFieldBegin('lower_phase_hash', TType.STRING, 7)
-      oprot.writeString(self.lower_phase_hash)
+    if self.lower_hash is not None:
+      oprot.writeFieldBegin('lower_hash', TType.STRING, 7)
+      oprot.writeString(self.lower_hash)
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
     oprot.writeStructEnd()
@@ -1167,7 +1167,7 @@ class VerificationRecordCommonInfo:
     value = (value * 31) ^ hash(self.verification_ts)
     value = (value * 31) ^ hash(self.signature)
     value = (value * 31) ^ hash(self.prior_hash)
-    value = (value * 31) ^ hash(self.lower_phase_hash)
+    value = (value * 31) ^ hash(self.lower_hash)
     return value
 
   def __repr__(self):
@@ -1409,7 +1409,7 @@ class Phase_3_msg:
   """
   Attributes:
    - record
-   - lower_phase_hashes
+   - lower_hash
    - p2_count
    - business_list
    - deploy_loc_list
@@ -1418,15 +1418,15 @@ class Phase_3_msg:
   thrift_spec = (
     None, # 0
     (1, TType.STRUCT, 'record', (VerificationRecordCommonInfo, VerificationRecordCommonInfo.thrift_spec), None, ), # 1
-    (2, TType.LIST, 'lower_phase_hashes', (TType.STRING,None), None, ), # 2
+    (2, TType.LIST, 'lower_hash', (TType.STRING,None), None, ), # 2
     (3, TType.I32, 'p2_count', None, None, ), # 3
     (4, TType.LIST, 'business_list', (TType.STRING,None), None, ), # 4
     (5, TType.LIST, 'deploy_loc_list', (TType.STRING,None), None, ), # 5
   )
 
-  def __init__(self, record=None, lower_phase_hashes=None, p2_count=None, business_list=None, deploy_loc_list=None,):
+  def __init__(self, record=None, lower_hash=None, p2_count=None, business_list=None, deploy_loc_list=None,):
     self.record = record
-    self.lower_phase_hashes = lower_phase_hashes
+    self.lower_hash = lower_hash
     self.p2_count = p2_count
     self.business_list = business_list
     self.deploy_loc_list = deploy_loc_list
@@ -1448,11 +1448,11 @@ class Phase_3_msg:
           iprot.skip(ftype)
       elif fid == 2:
         if ftype == TType.LIST:
-          self.lower_phase_hashes = []
+          self.lower_hash = []
           (_etype54, _size51) = iprot.readListBegin()
           for _i55 in xrange(_size51):
             _elem56 = iprot.readString()
-            self.lower_phase_hashes.append(_elem56)
+            self.lower_hash.append(_elem56)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -1495,10 +1495,10 @@ class Phase_3_msg:
       oprot.writeFieldBegin('record', TType.STRUCT, 1)
       self.record.write(oprot)
       oprot.writeFieldEnd()
-    if self.lower_phase_hashes is not None:
-      oprot.writeFieldBegin('lower_phase_hashes', TType.LIST, 2)
-      oprot.writeListBegin(TType.STRING, len(self.lower_phase_hashes))
-      for iter69 in self.lower_phase_hashes:
+    if self.lower_hash is not None:
+      oprot.writeFieldBegin('lower_hash', TType.LIST, 2)
+      oprot.writeListBegin(TType.STRING, len(self.lower_hash))
+      for iter69 in self.lower_hash:
         oprot.writeString(iter69)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
@@ -1530,7 +1530,7 @@ class Phase_3_msg:
   def __hash__(self):
     value = 17
     value = (value * 31) ^ hash(self.record)
-    value = (value * 31) ^ hash(self.lower_phase_hashes)
+    value = (value * 31) ^ hash(self.lower_hash)
     value = (value * 31) ^ hash(self.p2_count)
     value = (value * 31) ^ hash(self.business_list)
     value = (value * 31) ^ hash(self.deploy_loc_list)

--- a/blockchain/network.py
+++ b/blockchain/network.py
@@ -438,7 +438,7 @@ class ConnectionManager(object):
         phase_3_msg.p2_count = verification_info['p2_count']
         phase_3_msg.business_list = verification_info['business_list']
         phase_3_msg.deploy_loc_list = verification_info['deploy_location_list']
-        phase_3_msg.lower_hash = verification_info['lower_hash']
+        phase_3_msg.lower_hashes = verification_info['lower_hashes']
 
         for node in self.peer_dict[phase_type]:
             try:

--- a/blockchain/network.py
+++ b/blockchain/network.py
@@ -438,7 +438,7 @@ class ConnectionManager(object):
         phase_3_msg.p2_count = verification_info['p2_count']
         phase_3_msg.business_list = verification_info['business_list']
         phase_3_msg.deploy_loc_list = verification_info['deploy_location_list']
-        phase_3_msg.lower_phase_hashes = verification_info['lower_phase_hashes']
+        phase_3_msg.lower_hash = verification_info['lower_hash']
 
         for node in self.peer_dict[phase_type]:
             try:

--- a/blockchain/processing.py
+++ b/blockchain/processing.py
@@ -416,17 +416,17 @@ class ProcessingNode(object):
                 phase_2_record = thrift_record_to_dict(phase_2_info.record)
                 phase_2_record['phase'] = phase
 
-                lower_hash = [record['signature']['hash'] for record in phase_2_records]
+                lower_hashes = [record['signature']['hash'] for record in phase_2_records]
                 # TODO: add a structure such as a tuple to pair signatory with it's appropriate hash (signatory, hash)
                 # TODO: and store that instead of lower_phase_hashes also add said structure to phase_3_msg in thrift
                 verification_info = {
-                    'lower_hash': lower_hash,
+                    'lower_hashes': lower_hashes,
                     'p2_count': len(signatories),
                     'business_list': list(businesses),
                     'deploy_location_list': list(locations)
                 }
 
-                lower_hash = str(deep_hash(lower_hash))
+                lower_hash = str(deep_hash(lower_hashes))
 
                 # sign verification and rewrite record
                 block_info = sign_verification_record(self.network.this_node.node_id,
@@ -491,7 +491,7 @@ class ProcessingNode(object):
         phase_3_record = thrift_record_to_dict(phase_3_info.record)
 
         p3_verification_info = {
-            'lower_hash': phase_3_info.lower_hash,
+            'lower_hashes': phase_3_info.lower_hashes,
             'p2_count': phase_3_info.p2_count,
             'business_list': phase_3_info.business_list,
             'deploy_location_list': phase_3_info.deploy_loc_list

--- a/blockchain/processing.py
+++ b/blockchain/processing.py
@@ -251,12 +251,12 @@ class ProcessingNode(object):
             prior_block_hash = self.get_prior_hash(origin_id, phase)
             verification_info = approved_transactions
 
-            lower_phase_hash = str(deep_hash(0))
+            lower_hash = str(deep_hash(0))
 
             # sign approved transactions
             block_info = sign_verification_record(signatory,
                                                   prior_block_hash,
-                                                  lower_phase_hash,
+                                                  lower_hash,
                                                   self.service_config['public_key'],
                                                   self.service_config['private_key'],
                                                   current_block_id,
@@ -318,12 +318,12 @@ class ProcessingNode(object):
                 'deploy_location': self.network.deploy_location
             }
 
-            lower_phase_hash = phase_1_record['signature']['hash']
+            lower_hash = phase_1_record['signature']['hash']
 
             # sign verification and rewrite record
             block_info = sign_verification_record(self.network.this_node.node_id,
                                                   prior_block_hash,
-                                                  lower_phase_hash,
+                                                  lower_hash,
                                                   self.service_config['public_key'],
                                                   self.service_config['private_key'],
                                                   phase_1_record['block_id'],
@@ -416,22 +416,22 @@ class ProcessingNode(object):
                 phase_2_record = thrift_record_to_dict(phase_2_info.record)
                 phase_2_record['phase'] = phase
 
-                lower_phase_hashes = [record['signature']['hash'] for record in phase_2_records]
+                lower_hash = [record['signature']['hash'] for record in phase_2_records]
                 # TODO: add a structure such as a tuple to pair signatory with it's appropriate hash (signatory, hash)
                 # TODO: and store that instead of lower_phase_hashes also add said structure to phase_3_msg in thrift
                 verification_info = {
-                    'lower_phase_hashes': lower_phase_hashes,
+                    'lower_hash': lower_hash,
                     'p2_count': len(signatories),
                     'business_list': list(businesses),
                     'deploy_location_list': list(locations)
                 }
 
-                lower_phase_hash = str(deep_hash(lower_phase_hashes))
+                lower_hash = str(deep_hash(lower_hash))
 
                 # sign verification and rewrite record
                 block_info = sign_verification_record(self.network.this_node.node_id,
                                                       prior_block_hash,
-                                                      lower_phase_hash,
+                                                      lower_hash,
                                                       self.service_config['public_key'],
                                                       self.service_config['private_key'],
                                                       phase_2_record['block_id'],
@@ -491,7 +491,7 @@ class ProcessingNode(object):
         phase_3_record = thrift_record_to_dict(phase_3_info.record)
 
         p3_verification_info = {
-            'lower_phase_hashes': phase_3_info.lower_phase_hashes,
+            'lower_hash': phase_3_info.lower_hash,
             'p2_count': phase_3_info.p2_count,
             'business_list': phase_3_info.business_list,
             'deploy_location_list': phase_3_info.deploy_loc_list
@@ -504,12 +504,12 @@ class ProcessingNode(object):
 
             phase_3_record['phase'] = phase
 
-            lower_phase_hash = phase_3_record['signature']['hash']
+            lower_hash = phase_3_record['signature']['hash']
 
             # sign verification and rewrite record
             block_info = sign_verification_record(self.network.this_node.node_id,
                                                   prior_block_hash,
-                                                  lower_phase_hash,
+                                                  lower_hash,
                                                   self.service_config['public_key'],
                                                   self.service_config['private_key'],
                                                   phase_3_record['block_id'],

--- a/blockchain/query_svc.py
+++ b/blockchain/query_svc.py
@@ -57,6 +57,7 @@ class QueryHandler(tornado.web.RequestHandler):
             'block_id': None,
             'transaction_type': None,
             'create_ts': None,
+            'transaction_ts': None,
             'business_unit': None,
             'family_of_business': None,
             'line_of_business': None,

--- a/blockchain/query_svc.py
+++ b/blockchain/query_svc.py
@@ -56,6 +56,12 @@ class QueryHandler(tornado.web.RequestHandler):
         self.query_fields = {
             'block_id': None,
             'transaction_type': None,
+            'create_ts': None,
+            'business_unit': None,
+            'family_of_business': None,
+            'line_of_business': None,
+            'signature': None,
+            'status': None,
             'actor': None,
             'entity': None,
             'owner': None
@@ -120,7 +126,7 @@ def run():
     log = logging.getLogger("txn-service")
     log.info("Setting up argparse")
     parser = argparse.ArgumentParser(description='Process query info.', prog='python -m blockchain')
-    parser.add_argument('-p', '--port', default = 8000)
+    parser.add_argument('-p', '--port', default = 8080)
     parser.add_argument('--debug', default = True, action = "store_true")
 
     log.info("Parsing arguments")

--- a/blockchain/util/crypto.py
+++ b/blockchain/util/crypto.py
@@ -116,7 +116,7 @@ def sign_transaction(signatory,
 
 def sign_verification_record(signatory,
                              prior_block_hash,
-                             lower_hash,
+                             lower_hashes,
                              public_key_string,
                              private_key_string,
                              block_id,
@@ -128,7 +128,7 @@ def sign_verification_record(signatory,
     sign verification record (common and special info among each phase)
     * signatory (current node's name/id)
     * prior_block_hash
-    * lower_hash
+    * lower_hashes
     * public_key
     * private_key
     * block_id
@@ -150,9 +150,9 @@ def sign_verification_record(signatory,
     signature_ts = int(time.time())
     hashed_items = []
 
-    # append prior_block_hash and lower_hash
+    # append prior_block_hash and lower_hashes
     hashed_items.append(prior_block_hash)
-    hashed_items.append(lower_hash)
+    hashed_items.append(lower_hashes)
 
     # append my signing info for hashing
     hashed_items.append(signatory)
@@ -179,7 +179,7 @@ def sign_verification_record(signatory,
         "origin_id": origin_id,
         "phase": int(phase),
         "prior_hash": prior_block_hash,
-        "lower_hash": lower_hash,
+        "lower_hashes": lower_hashes,
         "verification_info": verification_info  # special phase info
     }
 

--- a/blockchain/util/crypto.py
+++ b/blockchain/util/crypto.py
@@ -179,7 +179,7 @@ def sign_verification_record(signatory,
         "origin_id": origin_id,
         "phase": int(phase),
         "prior_hash": prior_block_hash,
-        "lower_hashes": lower_hashes,
+        "lower_hash": lower_hash,
         "verification_info": verification_info  # special phase info
     }
 

--- a/blockchain/util/crypto.py
+++ b/blockchain/util/crypto.py
@@ -116,7 +116,7 @@ def sign_transaction(signatory,
 
 def sign_verification_record(signatory,
                              prior_block_hash,
-                             lower_phase_hash,
+                             lower_hash,
                              public_key_string,
                              private_key_string,
                              block_id,
@@ -128,7 +128,7 @@ def sign_verification_record(signatory,
     sign verification record (common and special info among each phase)
     * signatory (current node's name/id)
     * prior_block_hash
-    * lower_phase_hash
+    * lower_hash
     * public_key
     * private_key
     * block_id
@@ -150,9 +150,9 @@ def sign_verification_record(signatory,
     signature_ts = int(time.time())
     hashed_items = []
 
-    # append prior_block_hash and lower_phase_hash
+    # append prior_block_hash and lower_hash
     hashed_items.append(prior_block_hash)
-    hashed_items.append(lower_phase_hash)
+    hashed_items.append(lower_hash)
 
     # append my signing info for hashing
     hashed_items.append(signatory)
@@ -179,7 +179,7 @@ def sign_verification_record(signatory,
         "origin_id": origin_id,
         "phase": int(phase),
         "prior_hash": prior_block_hash,
-        "lower_phase_hash": lower_phase_hash,
+        "lower_hash": lower_hash,
         "verification_info": verification_info  # special phase info
     }
 
@@ -281,7 +281,7 @@ def validate_verification_record(verification_record, verification_info, log=log
         validate_signature(signature_block)
 
         hashed_items.append(record['prior_hash'])
-        hashed_items.append(record['lower_phase_hash'])
+        hashed_items.append(record['lower_hash'])
 
         hashed_items.append(signature_block['signatory'])
         hashed_items.append(signature_block['signature_ts'])

--- a/blockchain/util/crypto.py
+++ b/blockchain/util/crypto.py
@@ -116,7 +116,7 @@ def sign_transaction(signatory,
 
 def sign_verification_record(signatory,
                              prior_block_hash,
-                             lower_hashes,
+                             lower_hash,
                              public_key_string,
                              private_key_string,
                              block_id,
@@ -128,7 +128,7 @@ def sign_verification_record(signatory,
     sign verification record (common and special info among each phase)
     * signatory (current node's name/id)
     * prior_block_hash
-    * lower_hashes
+    * lower_hash
     * public_key
     * private_key
     * block_id
@@ -150,9 +150,9 @@ def sign_verification_record(signatory,
     signature_ts = int(time.time())
     hashed_items = []
 
-    # append prior_block_hash and lower_hashes
+    # append prior_block_hash and lower_hash
     hashed_items.append(prior_block_hash)
-    hashed_items.append(lower_hashes)
+    hashed_items.append(lower_hash)
 
     # append my signing info for hashing
     hashed_items.append(signatory)

--- a/blockchain/util/thrift_conversions.py
+++ b/blockchain/util/thrift_conversions.py
@@ -145,7 +145,7 @@ def get_verification_record(record):
     thrift_record.origin_id = record['origin_id']
     thrift_record.phase = record['phase']
     thrift_record.verification_ts = record['verification_ts']
-    thrift_record.lower_hash = record['lower_hash']
+    thrift_record.lower_hashes = record['lower_hashes']
 
     if record['prior_hash']:
         thrift_record.prior_hash = record['prior_hash']

--- a/blockchain/util/thrift_conversions.py
+++ b/blockchain/util/thrift_conversions.py
@@ -44,7 +44,7 @@ def thrift_record_to_dict(thrift_record):
         'verification_ts': thrift_record.verification_ts,
         'signature': convert_thrift_signature(thrift_record.signature),
         'prior_hash': thrift_record.prior_hash,
-        'lower_phase_hash': thrift_record.lower_phase_hash
+        'lower_hash': thrift_record.lower_hash
     }
 
 
@@ -145,7 +145,7 @@ def get_verification_record(record):
     thrift_record.origin_id = record['origin_id']
     thrift_record.phase = record['phase']
     thrift_record.verification_ts = record['verification_ts']
-    thrift_record.lower_phase_hash = record['lower_phase_hash']
+    thrift_record.lower_hash = record['lower_hash']
 
     if record['prior_hash']:
         thrift_record.prior_hash = record['prior_hash']

--- a/blockchain/util/thrift_conversions.py
+++ b/blockchain/util/thrift_conversions.py
@@ -145,7 +145,7 @@ def get_verification_record(record):
     thrift_record.origin_id = record['origin_id']
     thrift_record.phase = record['phase']
     thrift_record.verification_ts = record['verification_ts']
-    thrift_record.lower_hashes = record['lower_hashes']
+    thrift_record.lower_hash = record['lower_hash']
 
     if record['prior_hash']:
         thrift_record.prior_hash = record['prior_hash']

--- a/thrift/messaging.thrift
+++ b/thrift/messaging.thrift
@@ -117,7 +117,7 @@ struct VerificationRecordCommonInfo {
     4: i32 verification_ts,
     5: Signature signature,
     6: string prior_hash,
-    7: string lower_phase_hash
+    7: string lower_hash
 }
 
 struct Phase_1_msg {
@@ -136,7 +136,7 @@ struct Phase_2_msg {
 /* TODO: rename business_list and deploy_loc_list to businesses and deploy_locations respectively */
 struct Phase_3_msg {
     1: VerificationRecordCommonInfo record,
-    2: list<string> lower_phase_hashes,
+    2: list<string> lower_hash,
     3: i32 p2_count,
     4: list<string> business_list,
     5: list<string> deploy_loc_list

--- a/thrift/messaging.thrift
+++ b/thrift/messaging.thrift
@@ -136,7 +136,7 @@ struct Phase_2_msg {
 /* TODO: rename business_list and deploy_loc_list to businesses and deploy_locations respectively */
 struct Phase_3_msg {
     1: VerificationRecordCommonInfo record,
-    2: list<string> lower_hash,
+    2: list<string> lower_hashes,
     3: i32 p2_count,
     4: list<string> business_list,
     5: list<string> deploy_loc_list


### PR DESCRIPTION
Issue #28 added the ability to query by all header fields minus payload and signature. 
query list: transaction_id,create_ts,transaction_ts,business_unit,family_of_business,line_of_business,
owner,transaction_type,status,actor,entity. query_ts and transaction_ts use unix epoch timecode as input to query. 