### PR TITLE
Issue 20/phase5 definition change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,9 @@ logs/
 # pki
 pki/
 
+# .DStore
+.DS_Store
+
 # config
 configs/blockchain1.yml
 configs/blockchain2.yml

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Dragonchain
-The Dragonchain blockchain platform encompasses the development of an internal blockchain platform that provides an secure foundation providing non-repudiation, an network wide common interface, cryptographic capabilities, and efficient distribution of data to the edge.
 
-Dragonchain architecture represents a fast-paced emerging technology foundation for businesses with which to integrate and apply toward identified business problems and use cases. Businesses can develop and track assets more efficiently, deploy the use of cryptographic smart contracts within business workflows to increase efficiency across enterprise systems, and accelerate innovation.
+The Dragonchain platform attempts to simplify integration of real business applications onto a blockchain. Providing features such as easy integration, protection of business data, fixed 5 second blocks, currency agnosticism, and interop features, Dragonchain shines a new and interesting light on blockchain technology.
 
-This platform will allow ease of integration for real business applications. There is a growing need for simplified blockchain integration. The decentralized and singular approach to blockchain implementation is sometimes at odds with the real business need to protect information and control business processes. The Dragonchain blockchain platform seeks to solve these needs.
+#### No blockchain expertise required!
 
 ## Project Goals
 
@@ -24,7 +23,7 @@ Group blockchain standardization​)
 
 
 ## Quick Links
-* [Dragonchain Organization](https://github.com/dragonchain/dragonchain.github.io)
+* [Dragonchain Organization](https://dragonchain.github.io/)
 * [Dragonchain Architecture Document](https://github.com/dragonchain/dragonchain.github.io/blob/master/DragonchainArchitecture.pdf)
 * [Dragonchain Architecture Document DRAFT for comment](https://docs.google.com/document/d/1SRhBUeGN1dpm9sZsxTrqEHx0qL3_R3DPg-fcMUhUKWs)
 

--- a/blockchain/gen/messaging/BlockchainService.py
+++ b/blockchain/gen/messaging/BlockchainService.py
@@ -1659,11 +1659,11 @@ class get_peers_result:
       if fid == 0:
         if ftype == TType.LIST:
           self.success = []
-          (_etype75, _size72) = iprot.readListBegin()
-          for _i76 in xrange(_size72):
-            _elem77 = Node()
-            _elem77.read(iprot)
-            self.success.append(_elem77)
+          (_etype84, _size81) = iprot.readListBegin()
+          for _i85 in xrange(_size81):
+            _elem86 = Node()
+            _elem86.read(iprot)
+            self.success.append(_elem86)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -1686,8 +1686,8 @@ class get_peers_result:
     if self.success is not None:
       oprot.writeFieldBegin('success', TType.LIST, 0)
       oprot.writeListBegin(TType.STRUCT, len(self.success))
-      for iter78 in self.success:
-        iter78.write(oprot)
+      for iter87 in self.success:
+        iter87.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.unauthorized is not None:

--- a/blockchain/gen/messaging/ttypes.py
+++ b/blockchain/gen/messaging/ttypes.py
@@ -1047,6 +1047,7 @@ class VerificationRecordCommonInfo:
    - signature
    - prior_hash
    - lower_phase_hash
+   - public_transmission
   """
 
   thrift_spec = (
@@ -1058,9 +1059,10 @@ class VerificationRecordCommonInfo:
     (5, TType.STRUCT, 'signature', (Signature, Signature.thrift_spec), None, ), # 5
     (6, TType.STRING, 'prior_hash', None, None, ), # 6
     (7, TType.STRING, 'lower_phase_hash', None, None, ), # 7
+    (8, TType.MAP, 'public_transmission', (TType.STRING,None,TType.BOOL,None), None, ), # 8
   )
 
-  def __init__(self, block_id=None, origin_id=None, phase=None, verification_ts=None, signature=None, prior_hash=None, lower_phase_hash=None,):
+  def __init__(self, block_id=None, origin_id=None, phase=None, verification_ts=None, signature=None, prior_hash=None, lower_phase_hash=None, public_transmission=None,):
     self.block_id = block_id
     self.origin_id = origin_id
     self.phase = phase
@@ -1068,6 +1070,7 @@ class VerificationRecordCommonInfo:
     self.signature = signature
     self.prior_hash = prior_hash
     self.lower_phase_hash = lower_phase_hash
+    self.public_transmission = public_transmission
 
   def read(self, iprot):
     if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
@@ -1114,6 +1117,17 @@ class VerificationRecordCommonInfo:
           self.lower_phase_hash = iprot.readString()
         else:
           iprot.skip(ftype)
+      elif fid == 8:
+        if ftype == TType.MAP:
+          self.public_transmission = {}
+          (_ktype31, _vtype32, _size30 ) = iprot.readMapBegin()
+          for _i34 in xrange(_size30):
+            _key35 = iprot.readString()
+            _val36 = iprot.readBool()
+            self.public_transmission[_key35] = _val36
+          iprot.readMapEnd()
+        else:
+          iprot.skip(ftype)
       else:
         iprot.skip(ftype)
       iprot.readFieldEnd()
@@ -1152,6 +1166,14 @@ class VerificationRecordCommonInfo:
       oprot.writeFieldBegin('lower_phase_hash', TType.STRING, 7)
       oprot.writeString(self.lower_phase_hash)
       oprot.writeFieldEnd()
+    if self.public_transmission is not None:
+      oprot.writeFieldBegin('public_transmission', TType.MAP, 8)
+      oprot.writeMapBegin(TType.STRING, TType.BOOL, len(self.public_transmission))
+      for kiter37,viter38 in self.public_transmission.items():
+        oprot.writeString(kiter37)
+        oprot.writeBool(viter38)
+      oprot.writeMapEnd()
+      oprot.writeFieldEnd()
     oprot.writeFieldStop()
     oprot.writeStructEnd()
 
@@ -1168,6 +1190,7 @@ class VerificationRecordCommonInfo:
     value = (value * 31) ^ hash(self.signature)
     value = (value * 31) ^ hash(self.prior_hash)
     value = (value * 31) ^ hash(self.lower_phase_hash)
+    value = (value * 31) ^ hash(self.public_transmission)
     return value
 
   def __repr__(self):
@@ -1216,11 +1239,11 @@ class Phase_1_msg:
       elif fid == 2:
         if ftype == TType.LIST:
           self.transactions = []
-          (_etype33, _size30) = iprot.readListBegin()
-          for _i34 in xrange(_size30):
-            _elem35 = Transaction()
-            _elem35.read(iprot)
-            self.transactions.append(_elem35)
+          (_etype42, _size39) = iprot.readListBegin()
+          for _i43 in xrange(_size39):
+            _elem44 = Transaction()
+            _elem44.read(iprot)
+            self.transactions.append(_elem44)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -1241,8 +1264,8 @@ class Phase_1_msg:
     if self.transactions is not None:
       oprot.writeFieldBegin('transactions', TType.LIST, 2)
       oprot.writeListBegin(TType.STRUCT, len(self.transactions))
-      for iter36 in self.transactions:
-        iter36.write(oprot)
+      for iter45 in self.transactions:
+        iter45.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -1313,22 +1336,22 @@ class Phase_2_msg:
       elif fid == 2:
         if ftype == TType.LIST:
           self.valid_txs = []
-          (_etype40, _size37) = iprot.readListBegin()
-          for _i41 in xrange(_size37):
-            _elem42 = Transaction()
-            _elem42.read(iprot)
-            self.valid_txs.append(_elem42)
+          (_etype49, _size46) = iprot.readListBegin()
+          for _i50 in xrange(_size46):
+            _elem51 = Transaction()
+            _elem51.read(iprot)
+            self.valid_txs.append(_elem51)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
       elif fid == 3:
         if ftype == TType.LIST:
           self.invalid_txs = []
-          (_etype46, _size43) = iprot.readListBegin()
-          for _i47 in xrange(_size43):
-            _elem48 = Transaction()
-            _elem48.read(iprot)
-            self.invalid_txs.append(_elem48)
+          (_etype55, _size52) = iprot.readListBegin()
+          for _i56 in xrange(_size52):
+            _elem57 = Transaction()
+            _elem57.read(iprot)
+            self.invalid_txs.append(_elem57)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -1359,15 +1382,15 @@ class Phase_2_msg:
     if self.valid_txs is not None:
       oprot.writeFieldBegin('valid_txs', TType.LIST, 2)
       oprot.writeListBegin(TType.STRUCT, len(self.valid_txs))
-      for iter49 in self.valid_txs:
-        iter49.write(oprot)
+      for iter58 in self.valid_txs:
+        iter58.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.invalid_txs is not None:
       oprot.writeFieldBegin('invalid_txs', TType.LIST, 3)
       oprot.writeListBegin(TType.STRUCT, len(self.invalid_txs))
-      for iter50 in self.invalid_txs:
-        iter50.write(oprot)
+      for iter59 in self.invalid_txs:
+        iter59.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.business is not None:
@@ -1449,10 +1472,10 @@ class Phase_3_msg:
       elif fid == 2:
         if ftype == TType.LIST:
           self.lower_phase_hashes = []
-          (_etype54, _size51) = iprot.readListBegin()
-          for _i55 in xrange(_size51):
-            _elem56 = iprot.readString()
-            self.lower_phase_hashes.append(_elem56)
+          (_etype63, _size60) = iprot.readListBegin()
+          for _i64 in xrange(_size60):
+            _elem65 = iprot.readString()
+            self.lower_phase_hashes.append(_elem65)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -1464,20 +1487,20 @@ class Phase_3_msg:
       elif fid == 4:
         if ftype == TType.LIST:
           self.business_list = []
-          (_etype60, _size57) = iprot.readListBegin()
-          for _i61 in xrange(_size57):
-            _elem62 = iprot.readString()
-            self.business_list.append(_elem62)
+          (_etype69, _size66) = iprot.readListBegin()
+          for _i70 in xrange(_size66):
+            _elem71 = iprot.readString()
+            self.business_list.append(_elem71)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
       elif fid == 5:
         if ftype == TType.LIST:
           self.deploy_loc_list = []
-          (_etype66, _size63) = iprot.readListBegin()
-          for _i67 in xrange(_size63):
-            _elem68 = iprot.readString()
-            self.deploy_loc_list.append(_elem68)
+          (_etype75, _size72) = iprot.readListBegin()
+          for _i76 in xrange(_size72):
+            _elem77 = iprot.readString()
+            self.deploy_loc_list.append(_elem77)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -1498,8 +1521,8 @@ class Phase_3_msg:
     if self.lower_phase_hashes is not None:
       oprot.writeFieldBegin('lower_phase_hashes', TType.LIST, 2)
       oprot.writeListBegin(TType.STRING, len(self.lower_phase_hashes))
-      for iter69 in self.lower_phase_hashes:
-        oprot.writeString(iter69)
+      for iter78 in self.lower_phase_hashes:
+        oprot.writeString(iter78)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.p2_count is not None:
@@ -1509,15 +1532,15 @@ class Phase_3_msg:
     if self.business_list is not None:
       oprot.writeFieldBegin('business_list', TType.LIST, 4)
       oprot.writeListBegin(TType.STRING, len(self.business_list))
-      for iter70 in self.business_list:
-        oprot.writeString(iter70)
+      for iter79 in self.business_list:
+        oprot.writeString(iter79)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.deploy_loc_list is not None:
       oprot.writeFieldBegin('deploy_loc_list', TType.LIST, 5)
       oprot.writeListBegin(TType.STRING, len(self.deploy_loc_list))
-      for iter71 in self.deploy_loc_list:
-        oprot.writeString(iter71)
+      for iter80 in self.deploy_loc_list:
+        oprot.writeString(iter80)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()

--- a/blockchain/gen/messaging/ttypes.py
+++ b/blockchain/gen/messaging/ttypes.py
@@ -1613,11 +1613,119 @@ class Phase_4_msg:
   def __ne__(self, other):
     return not (self == other)
 
+class VerificationRecord:
+  """
+  Attributes:
+   - p1
+   - p2
+   - p3
+   - p4
+  """
+
+  thrift_spec = (
+    None, # 0
+    (1, TType.STRUCT, 'p1', (Phase_1_msg, Phase_1_msg.thrift_spec), None, ), # 1
+    (2, TType.STRUCT, 'p2', (Phase_2_msg, Phase_2_msg.thrift_spec), None, ), # 2
+    (3, TType.STRUCT, 'p3', (Phase_3_msg, Phase_3_msg.thrift_spec), None, ), # 3
+    (4, TType.STRUCT, 'p4', (Phase_4_msg, Phase_4_msg.thrift_spec), None, ), # 4
+  )
+
+  def __init__(self, p1=None, p2=None, p3=None, p4=None,):
+    self.p1 = p1
+    self.p2 = p2
+    self.p3 = p3
+    self.p4 = p4
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRUCT:
+          self.p1 = Phase_1_msg()
+          self.p1.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.p2 = Phase_2_msg()
+          self.p2.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRUCT:
+          self.p3 = Phase_3_msg()
+          self.p3.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRUCT:
+          self.p4 = Phase_4_msg()
+          self.p4.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('VerificationRecord')
+    if self.p1 is not None:
+      oprot.writeFieldBegin('p1', TType.STRUCT, 1)
+      self.p1.write(oprot)
+      oprot.writeFieldEnd()
+    if self.p2 is not None:
+      oprot.writeFieldBegin('p2', TType.STRUCT, 2)
+      self.p2.write(oprot)
+      oprot.writeFieldEnd()
+    if self.p3 is not None:
+      oprot.writeFieldBegin('p3', TType.STRUCT, 3)
+      self.p3.write(oprot)
+      oprot.writeFieldEnd()
+    if self.p4 is not None:
+      oprot.writeFieldBegin('p4', TType.STRUCT, 4)
+      self.p4.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    return
+
+
+  def __hash__(self):
+    value = 17
+    value = (value * 31) ^ hash(self.p1)
+    value = (value * 31) ^ hash(self.p2)
+    value = (value * 31) ^ hash(self.p3)
+    value = (value * 31) ^ hash(self.p4)
+    return value
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
 class Phase_5_msg:
   """
   Attributes:
    - transaction
-   - record
+   - verification_record
    - hash
    - misc
   """
@@ -1625,14 +1733,14 @@ class Phase_5_msg:
   thrift_spec = (
     None, # 0
     (1, TType.STRUCT, 'transaction', (Transaction, Transaction.thrift_spec), None, ), # 1
-    (2, TType.STRUCT, 'record', (VerificationRecordCommonInfo, VerificationRecordCommonInfo.thrift_spec), None, ), # 2
+    (2, TType.STRUCT, 'verification_record', (VerificationRecord, VerificationRecord.thrift_spec), None, ), # 2
     (3, TType.STRING, 'hash', None, None, ), # 3
     (4, TType.STRING, 'misc', None, None, ), # 4
   )
 
-  def __init__(self, transaction=None, record=None, hash=None, misc=None,):
+  def __init__(self, transaction=None, verification_record=None, hash=None, misc=None,):
     self.transaction = transaction
-    self.record = record
+    self.verification_record = verification_record
     self.hash = hash
     self.misc = misc
 
@@ -1653,8 +1761,8 @@ class Phase_5_msg:
           iprot.skip(ftype)
       elif fid == 2:
         if ftype == TType.STRUCT:
-          self.record = VerificationRecordCommonInfo()
-          self.record.read(iprot)
+          self.verification_record = VerificationRecord()
+          self.verification_record.read(iprot)
         else:
           iprot.skip(ftype)
       elif fid == 3:
@@ -1681,9 +1789,9 @@ class Phase_5_msg:
       oprot.writeFieldBegin('transaction', TType.STRUCT, 1)
       self.transaction.write(oprot)
       oprot.writeFieldEnd()
-    if self.record is not None:
-      oprot.writeFieldBegin('record', TType.STRUCT, 2)
-      self.record.write(oprot)
+    if self.verification_record is not None:
+      oprot.writeFieldBegin('verification_record', TType.STRUCT, 2)
+      self.verification_record.write(oprot)
       oprot.writeFieldEnd()
     if self.hash is not None:
       oprot.writeFieldBegin('hash', TType.STRING, 3)
@@ -1703,7 +1811,7 @@ class Phase_5_msg:
   def __hash__(self):
     value = 17
     value = (value * 31) ^ hash(self.transaction)
-    value = (value * 31) ^ hash(self.record)
+    value = (value * 31) ^ hash(self.verification_record)
     value = (value * 31) ^ hash(self.hash)
     value = (value * 31) ^ hash(self.misc)
     return value

--- a/blockchain/network.py
+++ b/blockchain/network.py
@@ -47,7 +47,7 @@ import gen.messaging.BlockchainService as BlockchainService
 import gen.messaging.ttypes as message_types
 
 from blockchain.util.thrift_conversions import convert_to_thrift_transaction, \
-                                               get_verification_record, \
+                                               convert_to_thrift_record, \
                                                thrift_record_to_dict, \
                                                thrift_transaction_to_dict
 
@@ -418,7 +418,7 @@ class ConnectionManager(object):
         """ returns thrift phase 1 message structure """
         verification_record = block_info['verification_record']
         transactions = map(convert_to_thrift_transaction, verification_record['verification_info'])
-        verification_record = get_verification_record(verification_record)
+        verification_record = convert_to_thrift_record(verification_record)
 
         phase_1_msg = message_types.Phase_1_msg()
         phase_1_msg.record = verification_record
@@ -443,7 +443,7 @@ class ConnectionManager(object):
         verification_info = verification_record['verification_info']
 
         phase_2_msg = message_types.Phase_2_msg()
-        phase_2_msg.record = get_verification_record(verification_record)
+        phase_2_msg.record = convert_to_thrift_record(verification_record)
         phase_2_msg.valid_txs = map(convert_to_thrift_transaction, verification_info['valid_txs'])
         phase_2_msg.invalid_txs = map(convert_to_thrift_transaction, verification_info['invalid_txs'])
         phase_2_msg.business = verification_info['business']
@@ -468,7 +468,7 @@ class ConnectionManager(object):
         verification_info = verification_record['verification_info']
 
         phase_3_msg = message_types.Phase_3_msg()
-        phase_3_msg.record = get_verification_record(verification_record)
+        phase_3_msg.record = convert_to_thrift_record(verification_record)
         phase_3_msg.p2_count = verification_info['p2_count']
         phase_3_msg.business_list = verification_info['business_list']
         phase_3_msg.deploy_loc_list = verification_info['deploy_location_list']

--- a/blockchain/network.py
+++ b/blockchain/network.py
@@ -65,10 +65,13 @@ sys.path.append('gen')
 
 
 DEFAULT_PORT = 9080
+
 NODE_ID_PROPERTY_KEY = 'node_id'
 OWNER_PROPERTY_KEY = 'owner'
 BUSINESS_PROPERTY_KEY = 'business'
 LOCATION_PROPERTY_KEY = 'deploy_location'
+PUB_TRANS_PROPERTY_KEY = 'public_transmission'
+
 INBOUND_TIMEOUT = 30  # seconds
 
 PHASE_1_NODE = 0b00001
@@ -130,6 +133,7 @@ class ConnectionManager(object):
         self.port = port
         self.business = None
         self.deploy_location = None
+        self.public_transmission = None
         # phase_type => {nodes} (dictionary of connected nodes)
         self.peer_dict = {}
         self.config = None
@@ -148,6 +152,8 @@ class ConnectionManager(object):
 
         # BLOCKING
         logger().info('Starting RMI service handler...')
+
+        # if testing network only without processing
         if processing_node is None:
             self.start_service_handler()
 
@@ -157,6 +163,10 @@ class ConnectionManager(object):
 
         self.business = self.config[BUSINESS_PROPERTY_KEY]
         self.deploy_location = self.config[LOCATION_PROPERTY_KEY]
+
+        # set public_transmission dictionary from yml config
+        if self.processing_node:
+            self.processing_node.public_transmission = self.config[PUB_TRANS_PROPERTY_KEY]
 
         self.this_node.host = self.host
         self.this_node.port = int(self.port)

--- a/blockchain/processing.py
+++ b/blockchain/processing.py
@@ -37,8 +37,6 @@ from blockchain.block import Block, \
 
 from blockchain.util.crypto import valid_transaction_sig, sign_verification_record, validate_verification_record, deep_hash
 
-from blockchain.util.thrift_conversions import thrift_record_to_dict, thrift_transaction_to_dict
-
 from db.postgres import transaction_db
 from db.postgres import verfication_db
 from db.postgres import postgres
@@ -513,7 +511,7 @@ class ProcessingNode(object):
             self.network.send_block(self.network.phase_4_broadcast, block_info, phase)
             print "phase 4 executed"
 
-    def _execute_phase_5(self, config, phase_4_info):
+    def _execute_phase_5(self, config, payload):
         """ public, Bitcoin bridge phase """
         print "phase 5 executed"
 

--- a/blockchain/processing.py
+++ b/blockchain/processing.py
@@ -80,6 +80,9 @@ class ProcessingNode(object):
         self._configured_phases = []
         self._register_configs()
 
+        # dictionary of public transmission flags. set by network, obtained through yml config file.
+        self.public_transmission = None
+
         phase = self.phase_config[0]['phase']
         self.network = network.ConnectionManager(self.service_config['host'], self.service_config['port'], 0b00001 << phase - 1, self)
 

--- a/blockchain/processing.py
+++ b/blockchain/processing.py
@@ -269,6 +269,9 @@ class ProcessingNode(object):
             # store signed phase specific data
             verfication_db.insert_verification(block_info['verification_record'])
 
+            if self.public_transmission['p1_pub_trans']:
+                self.network.public_broadcast(block_info, phase)
+
             # pass block info to network to send it to appropriate phase
             self.network.send_block(self.network.phase_1_broadcast, block_info, phase)
             print("Phase 1 signed " + str(len(approved_transactions)) + " transactions")
@@ -514,7 +517,7 @@ class ProcessingNode(object):
             self.network.send_block(self.network.phase_4_broadcast, block_info, phase)
             print "phase 4 executed"
 
-    def _execute_phase_5(self, config, payload):
+    def _execute_phase_5(self, config, phase_5_info):
         """ public, Bitcoin bridge phase """
         print "phase 5 executed"
 

--- a/blockchain/transaction_svc.py
+++ b/blockchain/transaction_svc.py
@@ -71,7 +71,7 @@ class TransactionHandler(tornado.web.RequestHandler):
         except:
             log.error("Failed to parse JSON.  Details: " + str(sys.exc_info()[1]))
             self.clear()
-            self.set_txn_status(log,400)
+            self.set_txn_status(log, 400)
             self.write(format_error("invalid input", "ERROR:  Failed to parse JSON\n"))
             return
 
@@ -87,26 +87,26 @@ class TransactionHandler(tornado.web.RequestHandler):
                                        self.application.public_key, txn)
 
                 tx_dao.insert_transaction(txn)
-                self.set_txn_status(log,201)
+                self.set_txn_status(log, 201)
                 self.write(json.dumps({
                     "transaction_id": txn["header"]["transaction_id"]
                 }))
                 return
             else:  # TODO: add status function accepts status code number and status string
-                self.set_txn_status(log,400)
+                self.set_txn_status(log, 400)
                 return
         except:
             log.error(str(sys.exc_info()))
             self.clear()
-            self.set_txn_status(log,500)
+            self.set_txn_status(log, 500)
             self.write(format_error("validation", str(sys.exc_info()[1])))
 
     def set_txn_status(self, log, status_code):
-        if(status_code == 400):
+        if status_code == 400:
             log.error("400: Bad Request. The request could not be understood by the server due to malformed syntax.")
-        elif(status_code == 201):
+        elif status_code == 201:
             log.info("201: Created. The request has been fulfilled and resulted in a new resource being created.")
-        elif(status_code == 500):
+        elif status_code == 500:
             log.error("500: Internal Error: The server encountered an unexpected condition which prevented it from fulfilling the request.")
         self.set_status(status_code)
 

--- a/blockchain/util/crypto.py
+++ b/blockchain/util/crypto.py
@@ -123,6 +123,7 @@ def sign_verification_record(signatory,
                              phase,
                              origin_id,
                              verification_ts,
+                             public_transmission,
                              verification_info):
     """
     sign verification record (common and special info among each phase)
@@ -180,6 +181,7 @@ def sign_verification_record(signatory,
         "phase": int(phase),
         "prior_hash": prior_block_hash,
         "lower_phase_hash": lower_phase_hash,
+        "public_transmission": public_transmission,
         "verification_info": verification_info  # special phase info
     }
 

--- a/blockchain/util/insert_db.py
+++ b/blockchain/util/insert_db.py
@@ -33,11 +33,14 @@ __email__ = "joe@dragonchain.org"
 """ only used for manually inserting data into nodes table """
 from blockchain.db.postgres import network_db as net_dao
 from blockchain.network import Node
+
 import os
+
+import uuid
 
 
 def load_required_nodes():
-    node = Node('fb6985bc-31b0-4916-be2e-7417874da20d', 'TWDC', 'localhost', '8084', '10000')
+    node = Node(str(uuid.uuid4()), 'TWDC', 'localhost', '8084', '10000')
     net_dao.insert_node(node)
     print('inserted node into database ' + os.environ.get('BLOCKCHAIN_DB_NAME') + " " + node.node_id)
 

--- a/blockchain/util/insert_db.py
+++ b/blockchain/util/insert_db.py
@@ -37,7 +37,7 @@ import os
 
 
 def load_required_nodes():
-    node = Node('6625e727-f5b8-45ab-87c7-d113192ce168', 'TWDC', 'localhost', '8083', '01000')
+    node = Node('fb6985bc-31b0-4916-be2e-7417874da20d', 'TWDC', 'localhost', '8084', '10000')
     net_dao.insert_node(node)
     print('inserted node into database ' + os.environ.get('BLOCKCHAIN_DB_NAME') + " " + node.node_id)
 

--- a/blockchain/util/thrift_conversions.py
+++ b/blockchain/util/thrift_conversions.py
@@ -139,7 +139,7 @@ def convert_to_thrift_signature(tx_signature):
     return thrift_signature
 
 
-def get_verification_record(record):
+def convert_to_thrift_record(record):
     """ returns a thrift representation of a dictionary VerificationRecordCommonInfo """
     thrift_record = message_types.VerificationRecordCommonInfo()
     thrift_record.block_id = record['block_id']

--- a/blockchain/util/thrift_conversions.py
+++ b/blockchain/util/thrift_conversions.py
@@ -34,7 +34,7 @@ __email__ = "joe@dragonchain.org"
 import blockchain.gen.messaging.ttypes as message_types
 
 
-# functions below used for converting thrift types to some other structure #
+# **** functions below used for converting thrift types to some other structure **** #
 def thrift_record_to_dict(thrift_record):
     """ returns a dictionary representation of a thrift verification_record """
     return {
@@ -44,7 +44,8 @@ def thrift_record_to_dict(thrift_record):
         'verification_ts': thrift_record.verification_ts,
         'signature': convert_thrift_signature(thrift_record.signature),
         'prior_hash': thrift_record.prior_hash,
-        'lower_phase_hash': thrift_record.lower_phase_hash
+        'lower_phase_hash': thrift_record.lower_phase_hash,
+        'public_transmission': thrift_record.public_transmission
     }
 
 
@@ -89,7 +90,7 @@ def convert_thrift_signature(thrift_signature):
     }
 
 
-# functions below used for converting to thrift types #
+# **** functions below used for converting to thrift types **** #
 def convert_to_thrift_transaction(transaction):
     """ returns a thrift representation of a transactions converted from a dictionary """
     thrift_transaction = message_types.Transaction()
@@ -139,13 +140,14 @@ def convert_to_thrift_signature(tx_signature):
 
 
 def get_verification_record(record):
-    """ returns a thrift representation of a dictionary verification record """
+    """ returns a thrift representation of a dictionary VerificationRecordCommonInfo """
     thrift_record = message_types.VerificationRecordCommonInfo()
     thrift_record.block_id = record['block_id']
     thrift_record.origin_id = record['origin_id']
     thrift_record.phase = record['phase']
     thrift_record.verification_ts = record['verification_ts']
     thrift_record.lower_phase_hash = record['lower_phase_hash']
+    thrift_record.public_transmission = record['public_transmission']
 
     if record['prior_hash']:
         thrift_record.prior_hash = record['prior_hash']

--- a/configs/blockchain.yml
+++ b/configs/blockchain.yml
@@ -5,9 +5,9 @@ deploy_location: SEATTLE
 
 # dictionary of public transmission flags (BitCoin, LiteCoin, etc...)
 public_transmission: 
-    p1_pub_trans: off
-    p2_pub_trans: off
-    p3_pub_trans: off
+    p1_pub_trans: on
+    p2_pub_trans: on
+    p3_pub_trans: on
     p4_pub_trans: off
 
 # host:port:id:phases

--- a/configs/blockchain.yml
+++ b/configs/blockchain.yml
@@ -3,6 +3,13 @@ owner: OWNER
 business: BUSINESS
 deploy_location: SEATTLE
 
+# dictionary of public transmission flags (BitCoin, LiteCoin, etc...)
+public_transmission: 
+    p1_pub_trans: on 
+    p2_pub_trans: off 
+    p3_pub_trans: off 
+    p4_pub_trans: off
+
 # host:port:id:phases
 # phase 1 = 00001
 # phase 2 = 00011 ...

--- a/configs/blockchain.yml
+++ b/configs/blockchain.yml
@@ -5,9 +5,9 @@ deploy_location: SEATTLE
 
 # dictionary of public transmission flags (BitCoin, LiteCoin, etc...)
 public_transmission: 
-    p1_pub_trans: on
+    p1_pub_trans: off
     p2_pub_trans: on
-    p3_pub_trans: on
+    p3_pub_trans: off
     p4_pub_trans: off
 
 # host:port:id:phases

--- a/configs/blockchain.yml
+++ b/configs/blockchain.yml
@@ -5,9 +5,9 @@ deploy_location: SEATTLE
 
 # dictionary of public transmission flags (BitCoin, LiteCoin, etc...)
 public_transmission: 
-    p1_pub_trans: on 
-    p2_pub_trans: off 
-    p3_pub_trans: off 
+    p1_pub_trans: off
+    p2_pub_trans: off
+    p3_pub_trans: off
     p4_pub_trans: off
 
 # host:port:id:phases

--- a/thrift/messaging.thrift
+++ b/thrift/messaging.thrift
@@ -117,7 +117,8 @@ struct VerificationRecordCommonInfo {
     4: i32 verification_ts,
     5: Signature signature,
     6: string prior_hash,
-    7: string lower_phase_hash
+    7: string lower_phase_hash,
+    8: map<string, bool> public_transmission
 }
 
 struct Phase_1_msg {

--- a/thrift/messaging.thrift
+++ b/thrift/messaging.thrift
@@ -146,9 +146,16 @@ struct Phase_4_msg {
     1: VerificationRecordCommonInfo record
 }
 
+union VerificationRecord {
+    1: Phase_1_msg p1,
+    2: Phase_2_msg p2,
+    3: Phase_3_msg p3,
+    4: Phase_4_msg p4
+}
+
 union Phase_5_msg {
     1: Transaction transaction,
-    2: VerificationRecordCommonInfo record,
+    2: VerificationRecord verification_record,
     /* Level 5 node will NOT hash this field */
     3: string hash,
     /* Level 5 node WILL hash this field */


### PR DESCRIPTION
issue #20 

`Phase_5_msg` in `messaging.thrift` is now a union that accepts either a `Transaction`, `VerificationRecord`, `hash` or a `miscellaneous string`.

`VerificationRecord` is a union that can either be a phase 1, 2, 3 or 4 `thrift` message type.

Implemented a public broadcast function in `network` that takes in a block, sets `VerificationRecord` and `phase_5_msg` and sends the block out to all known phase 5 nodes for `public transmission`.

Added public transmission on/off switches for all phases to the `blockchain.yml` network config. i.e if a config is set to `on` for phase 2, that block will be sent for `public transmission` by all phase 2 nodes it is sent to. If it's set to `off`, it is not sent for `public transmission`. Each phase checks for public transmission switches.

Added `public transmission` structure to the `VerificationRecordCommonInfo`.

Moved some logic that's now being used in several places into functions.

Refactored a few things.

Ran and tested several times without issues.
