### PR TITLE
init commit -- adding payload hash directly onto txn table for added …

### DIFF
--- a/blockchain/db/postgres/transaction_db.py
+++ b/blockchain/db/postgres/transaction_db.py
@@ -54,13 +54,14 @@ SQL_INSERT = """INSERT into transactions (
                             family_of_business,
                             line_of_business,
                             payload,
+                            payload_hash,
                             signature,
                             owner,
                             transaction_type,
                             status,
                             actor,
                             entity
-                          ) VALUES  (%s, to_timestamp(%s), to_timestamp(%s), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
+                          ) VALUES  (%s, to_timestamp(%s), to_timestamp(%s), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
 SQL_UPDATE = """UPDATE transactions SET status = %s, block_id = %s WHERE transaction_id = %s"""
 SQL_FIXATE_BLOCK = """UPDATE transactions SET status='pending', block_id=%i WHERE status = 'new' AND transaction_ts >= to_timestamp(%i) AND transaction_ts <= to_timestamp(%i)"""
 
@@ -228,6 +229,7 @@ def insert_transaction(txn):
         header["family_of_business"],
         header["line_of_business"],
         Json(txn["payload"]),
+        txn["payload_hash"],
         Json(txn["signature"]),
         header["owner"],
         header["transaction_type"],

--- a/blockchain/util/crypto.py
+++ b/blockchain/util/crypto.py
@@ -90,10 +90,14 @@ def sign_transaction(signatory,
     # put hashed transaction payload back and append to hashed_items
     if transaction["payload"]:
         log.info("Hashing payload")
-        hashed_items.append(deep_hash(transaction["payload"]))
-        # generate hash with with hashed payload included
+        payload_hash = deep_hash(transaction["payload"])
+        hashed_items.append(payload_hash)
+        # generate hash with hashed payload included
         log.info("Generating hash")
         hash = final_hash(hashed_items)
+
+        # add payload hash to transaction so it can be stored in transaction table
+        transaction["payload_hash"] = payload_hash
     else:
         hash = stripped_hash
 

--- a/sql/txpool.sql
+++ b/sql/txpool.sql
@@ -75,6 +75,8 @@ CREATE TABLE IF NOT EXISTS transactions (
     /* what are a few examples? */
     payload JSON,
 
+    payload_hash VARCHAR(500),
+
     /* signatures */
     signature JSON,
 


### PR DESCRIPTION
Adding payload hash directly onto transaction table.

Having this extra field will enable some future capabilities, such as allowing a user prove a given payload/document exists on the blockchain. This can be done by hashing it themselves and confirming that a corresponding transaction exists.