### PR TITLE
added shell script to automate thrift generation

### DIFF
--- a/scripts/gen_thrift.sh
+++ b/scripts/gen_thrift.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo Generating Thrift files
+thrift -r --gen py ../thrift/messaging.thrift
+echo Thrift files generated
+sleep 2
+echo Copying required files to gen folder
+cp gen-py/messaging/ttypes.py ../blockchain/gen/messaging/
+cp gen-py/messaging/BlockchainService-remote ../blockchain/gen/messaging/
+cp gen-py/messaging/blockchainService.py ../blockchain/gen/messaging/
+sleep 1
+echo Deleting gen-py directory from Thrift folder
+rm -rf gen-py
+echo Process complete


### PR DESCRIPTION
Issue #84 Wrote and verified script worked for generating thrift files, copying Blockchain-Service.py, BlockchainService-remote and ttypes.py into the blockchain/gen folder and finally deleting the gen-py folder from the thrift generation. 