### PR TITLE
Setup and execution improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ configs/
 
 #docker
 docker/custom*compose.yml
+
+# Emacs
+*~

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ If you have Apache Thrift installed you can regenerate these classes by using th
 
 * Signing Key Generation `openssl ecparam -name secp224r1 -genkey -out <Dragonchain Home>/pki/sk.pem`
 * Verifying Key Generation `openssl ec -in pki/sk.pem -pubout -out <Dragonchain Home>/pki/pk.pem`
+* **The signing key must be kept private.**  The pki directory is listed in .gitignore to prevent accidentally pushing keys to a public repository.
+
+### Logs
+
+Pre-create a directory for log files before execution.
+
+    mkdir logs
 
 # Execution
 

--- a/blockchain/processing.py
+++ b/blockchain/processing.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 Copyright 2016 Disney Connected and Advanced Technologies
 

--- a/blockchain/query_svc.py
+++ b/blockchain/query_svc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 Copyright 2016 Disney Connected and Advanced Technologies
 

--- a/blockchain/transaction_svc.py
+++ b/blockchain/transaction_svc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 Copyright 2016 Disney Connected and Advanced Technologies
 


### PR DESCRIPTION
1. Set up .gitignore to ignore Emacs automatic backup files.
2. Document a warning that the signing key must be kept private, and that we
   have set up .gitignore to prevent accidentally committing them to source
   control.
3. Document requirement to create logs directory.
4. Add shebang lines to call the Python interpreter.