### PR TITLE
Add eclipse specific project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,5 +106,12 @@ configs/
 #docker
 docker/custom*compose.yml
 
+#eclipse,pydev
+.metadata/
+.project
+.pydevproject
+
 # Emacs
-*~
+*
+
+~


### PR DESCRIPTION
This change adds 3 entries to the .gitignore file to ignore eclipse specific files.  Some people like to develop in eclipse.