### PR TITLE
use unbuffered output from the processing node in docker

### DIFF
--- a/docker/Processor_Dockerfile
+++ b/docker/Processor_Dockerfile
@@ -28,4 +28,4 @@ COPY ./configs/blockchain.yml .
 
 COPY ./docker/bootstrap.sh .
 
-CMD ["bash", "bootstrap.sh", "python processing.py --private-key $PRIVATE_KEY --public-key $PUBLIC_KEY --port 8080 --phase 1"]
+CMD ["bash", "bootstrap.sh", "python -u processing.py --private-key $PRIVATE_KEY --public-key $PUBLIC_KEY --port 8080 --phase 1"]


### PR DESCRIPTION
Resolve issue #150 by using unbuffered python output in docker containers.