### PR TITLE
Prep for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Latest
+## 4.0.2
 
 - **Bugs:**
   - Fix a bug where getting the cached list of verifications for a block would always fail

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.9.238
+boto3==1.9.240
 redis==3.3.8
 apscheduler==3.6.1
 jsonpath==0.82


### PR DESCRIPTION
## Description

Prepping for a 4.0.2 bug-fix release.
Will add an integration test in the python SDK for the interchain 409 before releasing.

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] changelog has been modified for the changes
