### PR TITLE
Move from python3.7 to python3.8

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,5 @@
         "py38"
     ],
     "editor.formatOnSave": true,
-    "restructuredtext.confPath": "${workspaceFolder}/docs",
-    "python.pythonPath": ".venv/bin/python3.8"
+    "restructuredtext.confPath": "${workspaceFolder}/docs"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,8 +9,9 @@
         "-l",
         "150",
         "-t",
-        "py37"
+        "py38"
     ],
     "editor.formatOnSave": true,
-    "restructuredtext.confPath": "${workspaceFolder}/docs"
+    "restructuredtext.confPath": "${workspaceFolder}/docs",
+    "python.pythonPath": ".venv/bin/python3.8"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,18 @@
 - **Feature:**
   - Add performance improvements when creating transactions and processing L1 blocks
   - Add interchain support for binance
+- **Bugs:**
+  - Change L5 block redisearch insert to upsert to prevent an occasional edge-case error which could cause an L5 to get stuck
+  - Don't require tail to be explicitly provided when requesting smart contract logs
+  - Fix a bug where L2+ chains could have the transaction processor go into a failure loop if a block failed to write to storage at some point
+  - Fix a bug where Ethereum L5 nodes could estimate a gas price of 0 for low-activity networks
 - **Packaging:**
   - Update redisearch, boto3, and apscheduler dependencies
   - Add bnb-tx, pycoin, and mnemonic dependencies for binance
 - **Development:**
   - Revert manual redisearch fixes with dependency fixes
   - Change the way that transaction 404 stubbing is handled for pending transactions
-- **Bugs:**
-  - Change L5 block redisearch insert to upsert to prevent an occasional edge-case error which could cause an L5 to get stuck
-  - Don't require tail to be explicitly provided when requesting smart contract logs
-  - Fix a bug where L2+ chains could have the transaction processor go into a failure loop if a block failed to write to storage at some point
-  - Fix a bug where Ethereum L5 nodes could estimate a gas price of 0 for low-activity networks
+  - Update to python 3.8
 
 ## 4.1.0
 
@@ -57,7 +58,6 @@ field where necessary.
   - Enforce `appVersion` in Chart.yaml and image version tags to be always up to date (and add associated version bump helper function in `tools.sh`)
   - Add strict helm lint checking
   - Add a public docker container for the current build of the master (development) branch (`dragonchain/dragonchain_core:edge`)
-  - Update to python 3.8
 
 ## 4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
   - Revert manual redisearch fixes with dependency fixes
   - Change the way that transaction 404 stubbing is handled for pending transactions
   - Update to python 3.8
-  - Enforce using python from .venv for vscode python interpreter
 
 ## 4.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ field where necessary.
   - Enforce `appVersion` in Chart.yaml and image version tags to be always up to date (and add associated version bump helper function in `tools.sh`)
   - Add strict helm lint checking
   - Add a public docker container for the current build of the master (development) branch (`dragonchain/dragonchain_core:edge`)
+  - Update to python 3.8
 
 ## 4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Revert manual redisearch fixes with dependency fixes
   - Change the way that transaction 404 stubbing is handled for pending transactions
   - Update to python 3.8
+  - Enforce using python from .venv for vscode python interpreter
 
 ## 4.1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine as base
+FROM python:3.8-alpine as base
 
 WORKDIR /usr/src/core
 # Install necessary base dependencies and set UTC timezone for apscheduler
@@ -15,7 +15,7 @@ RUN python3 -m pip install -r requirements.txt
 
 FROM base AS release
 # Copy the installed python dependencies from the builder
-COPY --from=builder /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
 COPY --from=builder /usr/local/bin/gunicorn /usr/local/bin/gunicorn
 # Copy our actual application
 COPY --chown=1000:1000 . .

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ can do.
 
 In order to develop locally you should be able to run `./tools.sh full-test` and have all checks pass. For this, a few requirements should be met:
 
-1. Ensure that you have python 3.7 installed locally
+1. Ensure that you have python 3.8 installed locally
 1. Install OS dependencies for building various python package dependencies:
    - On an arch linux system (with pacman): `./tools.sh arch-install`
    - On a debian-based linux system (with apt): `./tools.sh deb-install` (Note on newer Ubuntu installations
@@ -76,7 +76,7 @@ to be separated from the rest of the (potentially conflicting) packages from the
 
 In order to do this, instead of step 3 above, perform the following steps:
 
-1. Ensure you have python venv installed, and run `python3.7 -m venv .venv`
+1. Ensure you have python venv installed, and run `python3.8 -m venv .venv`
 1. Activate the virtual environment in your shell by running `source .venv/bin/activate`
 1. Upgrade the setup dependencies for the virtual environment: `pip install -U pip setuptools`
 1. Install the core dependencies: `pip install -r requirements.txt`

--- a/cicd/Dockerfile.dependencies
+++ b/cicd/Dockerfile.dependencies
@@ -1,5 +1,5 @@
 # This container is used as a base by Dockerfile.test in order to speed up dependency install for testing purposes only
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Install helm for linting chart, and yq for building docs
 RUN wget -O helm-v2.14.3-linux-amd64.tar.gz 'https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz' && \

--- a/cicd/Dockerfile.test
+++ b/cicd/Dockerfile.test
@@ -1,4 +1,4 @@
-# Change FROM to python:3.7-alpine to test without the dependencies container
+# Change FROM to python:3.8-alpine to test without the dependencies container
 FROM dragonchain/dragonchain_core_dependencies:latest as base
 
 # Install Helm for chart linting and/or yq for doc builds if it doesn't exist
@@ -28,7 +28,7 @@ RUN python3 -m pip install --upgrade -r dev_requirements.txt
 
 FROM base AS release
 # Copy the installed python dependencies from the builder
-COPY --from=builder /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
 # Sphinx is needed to build the docs
 COPY --from=builder /usr/local/bin/sphinx-build /usr/local/bin/sphinx-build
 # Copy our actual application

--- a/dragonchain/broadcast_processor/broadcast_functions_utest.py
+++ b/dragonchain/broadcast_processor/broadcast_functions_utest.py
@@ -25,11 +25,10 @@ from dragonchain.broadcast_processor import broadcast_functions
 from dragonchain import exceptions
 
 
-def async_test(function):
+def async_test(coro):
     def wrapper(*args, **kwargs):
-        coro = asyncio.coroutine(function)
-        future = coro(*args, **kwargs)
-        asyncio.get_event_loop().run_until_complete(future)
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(coro(*args, **kwargs))
 
     return wrapper
 

--- a/dragonchain/broadcast_processor/broadcast_processor_utest.py
+++ b/dragonchain/broadcast_processor/broadcast_processor_utest.py
@@ -25,11 +25,10 @@ from dragonchain.broadcast_processor import broadcast_processor
 from dragonchain import exceptions
 
 
-def async_test(function):
+def async_test(coro):
     def wrapper(*args, **kwargs):
-        coro = asyncio.coroutine(function)
-        future = coro(*args, **kwargs)
-        asyncio.get_event_loop().run_until_complete(future)
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(coro(*args, **kwargs))
 
     return wrapper
 

--- a/dragonchain/lib/database/redis_utest.py
+++ b/dragonchain/lib/database/redis_utest.py
@@ -22,11 +22,10 @@ from unittest.mock import patch, MagicMock
 from dragonchain.lib.database import redis
 
 
-def async_test(function):
+def async_test(coro):
     def wrapper(*args, **kwargs):
-        coro = asyncio.coroutine(function)
-        future = coro(*args, **kwargs)
-        asyncio.get_event_loop().run_until_complete(future)
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(coro(*args, **kwargs))
 
     return wrapper
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 # Platform specs
-python_version=3.7
+python_version=3.8
 platform=linux
 
 cache_dir=.mypy_cache

--- a/tools.sh
+++ b/tools.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -e
 
-# Check and try to use python3.7 explicitly, if possible
-if command -v python3.7 > /dev/null 2>&1; then
-    py_exec=python3.7
+# Check and try to use python3.8 explicitly, if possible
+if command -v python3.8 > /dev/null 2>&1; then
+    py_exec=python3.8
 else
     py_exec=python3
 fi

--- a/tools.sh
+++ b/tools.sh
@@ -51,9 +51,9 @@ elif [ "$1" = "lint" ]; then
     if ! grep "version: $(cat .version)" helm/opensource-config.yaml > /dev/null 2>&1; then printf "Helm opensource-config.yaml version doesn't match .version file\\nRun tools.sh version\\n" && exit 1; fi
     helm lint helm/dragonchain-k8s/ --strict
     find dragonchain -name "*.py" -exec $py_exec -m flake8 {} +
-    $py_exec -m black --check -l 150 -t py37 dragonchain
+    $py_exec -m black --check -l 150 -t py38 dragonchain
 elif [ "$1" = "format" ]; then
-    $py_exec -m black -l 150 -t py37 dragonchain
+    $py_exec -m black -l 150 -t py38 dragonchain
 elif [ "$1" = "bandit" ]; then
     $py_exec -m bandit -r dragonchain
 elif [ "$1" = "docs" ]; then


### PR DESCRIPTION
## Description

Closes #212

This PR updates dragonchain to use python3.8

Note that not all of our development tools (namely flake8) full support python3.8, so although we can use python3.8, we can't necessarily use all of the new syntax features (such as walrus operators) of python3.8 until those are also updated, or tests will fail.

Not a huge deal, and shouldn't block us from getting the other python3.8 benefits in the mean-time.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `./tools.sh full-test` passes
- [x] changelog has been modified for the changes
