### PR TITLE
Fix disable contract schedule update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Fix a bug where L5s returned a 404 for the status endpoint when a default interchain was not yet set
   - Fix a bug where very large payloads could attempt to be cached and crash the caching redis
   - Fix a bug so that non-existant routes in the api now properly return a 404
+  - Fix a bug where accepting the disable_schedule parameter when updating a contract didn't do anything
 - **Documentation:**
   - Change dragonchain deployment docs to reflect helm install changes from helm repository with pinned version
   - Stop posting helm chart directly to docs

--- a/dragonchain/lib/dto/smart_contract_model.py
+++ b/dragonchain/lib/dto/smart_contract_model.py
@@ -71,6 +71,7 @@ def new_from_build_task(data: Mapping[str, Any]) -> "SmartContractModel":
             execution_order=data["execution_order"],
             start_state=data["start_state"],
             desired_state=data["desired_state"],
+            disable_schedule=data["disable_schedule"],
         )
     else:
         raise NotImplementedError(f"Version {data.get('version')} is not supported")
@@ -258,6 +259,7 @@ class SmartContractModel(model.Model):
             "execution_order": self.execution_order,
             "start_state": self.start_state,
             "desired_state": self.desired_state,
+            "disable_schedule": self.disable_schedule,
         }
 
     def validate_schedule(self) -> None:


### PR DESCRIPTION
## Description

Disable schedule wasn't getting properly exported on contract build jobs. Now they are

Ran locally to test with removing both a cron schedule, and a seconds interval schedule, which worked correctly.

Fixes #213 

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] changelog has been modified for the changes
