### PR TITLE
set minimum gas price for ethereum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Change L5 block redisearch insert to upsert to prevent an occasional edge-case error which could cause an L5 to get stuck
   - Don't require tail to be explicitly provided when requesting smart contract logs
   - Fix a bug where L2+ chains could have the transaction processor go into a failure loop if a block failed to write to storage at some point
+  - Fix a bug where Ethereum L5 nodes could estimate a gas price of 0 for low-activity networks
 
 ## 4.1.0
 

--- a/dragonchain/lib/dto/eth.py
+++ b/dragonchain/lib/dto/eth.py
@@ -263,7 +263,7 @@ class EthereumNetwork(model.InterchainModel):
             Gas price estimate in wei
         """
         _log.debug(f"[ETHEREUM] Getting estimated gas price")
-        gas_price = int(self.w3.eth.generateGasPrice())
+        gas_price = max(int(self.w3.eth.generateGasPrice()), 500000000)  # Calculate gas price, but set minimum to 0.5 gwei for safety
         _log.info(f"[ETHEREUM] Current estimated gas price: {gas_price}")
         return gas_price
 

--- a/dragonchain/lib/dto/eth.py
+++ b/dragonchain/lib/dto/eth.py
@@ -263,7 +263,7 @@ class EthereumNetwork(model.InterchainModel):
             Gas price estimate in wei
         """
         _log.debug(f"[ETHEREUM] Getting estimated gas price")
-        gas_price = max(int(self.w3.eth.generateGasPrice()), 500000000)  # Calculate gas price, but set minimum to 0.5 gwei for safety
+        gas_price = max(int(self.w3.eth.generateGasPrice()), 100000000)  # Calculate gas price, but set minimum to 0.1 gwei for safety
         _log.info(f"[ETHEREUM] Current estimated gas price: {gas_price}")
         return gas_price
 


### PR DESCRIPTION
## Description

L5 ethereum chains could estimate 0 for a gas price, which would cause transactions to fail.

This PR puts in a minimum gas price of 0.1 gwei for safety against this.

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] changelog has been modified for the changes
