### PR TITLE
Fix dragonnet registration recursion and only warn if chain cannot register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   - Fix a bug where L2+ chains could have the transaction processor go into a failure loop if a block failed to write to storage at some point
   - Fix a bug where Ethereum L5 nodes could estimate a gas price of 0 for low-activity networks
   - Fix a bug where an open-source chain couldn't build smart contracts due to a bad environment variable
-  - Fix a bug where a chain would infinitely retry to connect to dragon net regardless of the registration error
+  - Fix a bug where a chain could infinitely retry to connect to dragon net
 - **Packaging:**
   - Update redisearch, boto3, and apscheduler dependencies
   - Add bnb-tx, pycoin, and mnemonic dependencies for binance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   - Fix a bug where an open-source chain couldn't build smart contracts due to a bad environment variable
   - Fix a bug where a chain could infinitely retry to connect to dragon net
 - **Packaging:**
-  - Update redisearch, boto3, and apscheduler dependencies
+  - Update redisearch, boto3, apscheduler, and gunicorn dependencies
   - Add bnb-tx, pycoin, and mnemonic dependencies for binance
 - **Development:**
   - Revert manual redisearch fixes with dependency fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Fix a bug where L2+ chains could have the transaction processor go into a failure loop if a block failed to write to storage at some point
   - Fix a bug where Ethereum L5 nodes could estimate a gas price of 0 for low-activity networks
   - Fix a bug where an open-source chain couldn't build smart contracts due to a bad environment variable
+  - Fix a bug where a chain would infinitely retry to connect to dragon net regardless of the registration error
 - **Packaging:**
   - Update redisearch, boto3, and apscheduler dependencies
   - Add bnb-tx, pycoin, and mnemonic dependencies for binance

--- a/dragonchain/transaction_processor/level_1_actions.py
+++ b/dragonchain/transaction_processor/level_1_actions.py
@@ -29,6 +29,7 @@ from dragonchain.lib import matchmaking
 from dragonchain.lib import queue
 from dragonchain.lib import callback
 from dragonchain import logger
+from dragonchain import exceptions
 
 if TYPE_CHECKING:
     from dragonchain.lib.dto import transaction_model
@@ -43,7 +44,10 @@ _log = logger.get_logger()
 def execute() -> None:
     """Pops transactions off the queue, fixates them into a block and adds it to the chain"""
     if BROADCAST:
-        matchmaking.renew_registration_if_necessary()
+        try:
+            matchmaking.renew_registration_if_necessary()
+        except exceptions.MatchmakingError:
+            _log.warning("Could not register with matchmaking! Is your dragon net configuration valid?")
     t0 = time.time()
 
     # Pop off of queue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-boto3==1.10.9
+boto3==1.10.17
 redis==3.3.11
-apscheduler==3.6.2
+apscheduler==3.6.3
 jsonpath==0.82
 Flask==1.1.1
 requests==2.22.0
@@ -9,7 +9,7 @@ secp256k1==0.13.2
 web3==5.2.2
 kubernetes==10.0.1
 docker==4.1.0
-gunicorn[gevent]==19.9.0
+gunicorn[gevent]==20.0.0
 aiohttp[speedups]==3.6.2
 aioredis==1.3.0
 base58==1.0.3


### PR DESCRIPTION
Fixes #242 

## Description

This fixes the infinite recursion when trying to register with dragon net.

With these changes, it will only retry registering up to 2 times total in worst case scenario before failing.

This PR also makes it so that an L1 chain transaction processor doesn't have to have an active dragon net registration to work properly, even when dragon net broadcasting is enabled

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] tests are included
- [x] changelog has been modified for the changes
