### PR TITLE
reduce interchain timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **Development:**
   - Added hard limit to the number of L4 blocks included in an L5 block
   - Use independent model and dao for api keys
+  - Reduce interchain timeouts so client requests don't timeout
 
 ## 4.2.0
 

--- a/dragonchain/lib/dto/bnb.py
+++ b/dragonchain/lib/dto/bnb.py
@@ -368,7 +368,7 @@ class BinanceNetwork(model.InterchainModel):
         body = {"method": method, "jsonrpc": "2.0", "params": params, "id": "dontcare"}
         _log.debug(f"Binance RPC: -> {full_address} {body}")
         try:
-            response = requests.post(full_address, json=body, timeout=30)
+            response = requests.post(full_address, json=body, timeout=10)
         except Exception as e:
             raise exceptions.InterchainConnectionError(f"Error sending post request to binance node: {e}")
         _log.debug(f"Binance <- {response.status_code} {response.text}")
@@ -382,7 +382,7 @@ class BinanceNetwork(model.InterchainModel):
     def _call_node_api(self, path: str) -> Any:
         full_address = f"{self.node_url}:{self.api_port}/api/v1/{path}"
         try:
-            response = requests.get(full_address, timeout=30)
+            response = requests.get(full_address, timeout=10)
         except Exception as e:
             raise exceptions.InterchainConnectionError(f"Error sending get request to binance node: {e}")
         _log.debug(f"Binance <- {response.status_code} {response.text}")

--- a/dragonchain/lib/dto/bnb_utest.py
+++ b/dragonchain/lib/dto/bnb_utest.py
@@ -213,14 +213,14 @@ class TestBinanceMethods(unittest.TestCase):
         response = self.client._call_node_rpc("MyMethod", {"symbol": "BANANA"})
         self.assertEqual(response.json(), {"result": "MyResult"})
         mock_post.assert_called_once_with(
-            "b.a.n.a.n.a:27147/", json={"method": "MyMethod", "jsonrpc": "2.0", "params": {"symbol": "BANANA"}, "id": "dontcare"}, timeout=30
+            "b.a.n.a.n.a:27147/", json={"method": "MyMethod", "jsonrpc": "2.0", "params": {"symbol": "BANANA"}, "id": "dontcare"}, timeout=10
         )
 
     @patch("requests.get", return_value=MagicMock(status_code=200, json=MagicMock(return_value={"result": "MyResult"})))
     def test_api_request_success(self, mock_get):
         response = self.client._call_node_api("MyPath")
         self.assertEqual(response.json(), {"result": "MyResult"})
-        mock_get.assert_called_once_with("b.a.n.a.n.a:1169/api/v1/MyPath", timeout=30)
+        mock_get.assert_called_once_with("b.a.n.a.n.a:1169/api/v1/MyPath", timeout=10)
 
     @patch("dragonchain.lib.dto.bnb.requests.post")
     def test_rpc_request_error(self, mock_requests):

--- a/dragonchain/lib/dto/btc.py
+++ b/dragonchain/lib/dto/btc.py
@@ -308,7 +308,7 @@ class BitcoinNetwork(model.InterchainModel):
             self.rpc_address,
             json={"method": method, "params": list(args), "id": "1", "jsonrpc": "1.0"},
             headers={"Authorization": f"Basic {self.authorization}", "Content-Type": "text/plain"},
-            timeout=30,
+            timeout=20,
         )
         if r.status_code != 200:
             raise exceptions.InterchainConnectionError(f"Error from bitcoin node with http status code {r.status_code} | {r.text}")

--- a/dragonchain/lib/dto/btc_utest.py
+++ b/dragonchain/lib/dto/btc_utest.py
@@ -161,7 +161,7 @@ class TestBitcoinMethods(unittest.TestCase):
             "http://whatever",
             json={"method": "myMethod", "params": ["arg1", 2, True], "id": "1", "jsonrpc": "1.0"},
             headers={"Authorization": "Basic auth", "Content-Type": "text/plain"},
-            timeout=30,
+            timeout=20,
         )
 
     @patch("requests.post", return_value=MagicMock(status_code=200, json=MagicMock(return_value={"error": "MyResult"})))
@@ -171,7 +171,7 @@ class TestBitcoinMethods(unittest.TestCase):
             "http://whatever",
             json={"method": "myMethod", "params": ["arg1", 2, True], "id": "1", "jsonrpc": "1.0"},
             headers={"Authorization": "Basic auth", "Content-Type": "text/plain"},
-            timeout=30,
+            timeout=20,
         )
 
     @patch("dragonchain.lib.dto.btc.BitcoinNetwork.ping")


### PR DESCRIPTION
## Description

Integration tests were failing because the endpoints for interchains were timing out

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] tests are included
- [x] changelog has been modified for the changes
