### PR TITLE
Make redisearch optional on verification nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 4.3.1
 
+- **Feature:**
+  - Allow option for disabling redisearch on verification (L2+) nodes
+- **Packaging:**
+  - Update boto3, and web3 dependencies
+- **Development:**
+  - Add script to check for newer requirements.txt package versions
+
 ## 4.3.0
 
 - **Feature:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - **Feature:**
   - Allow option for disabling redisearch on verification (L2+) nodes
 - **Packaging:**
-  - Update boto3, and web3 dependencies
+  - Update boto3 dependencies
 - **Development:**
   - Add script to check for newer requirements.txt package versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## 4.3.1
 
 - **Feature:**
-  - Allow option for disabling redisearch on verification (L2+) nodes
+  - Allow option for turning redisearch on/off with verification (L2+) nodes (and disable by default)
 - **Packaging:**
   - Update boto3 dependencies
+  - Change default node level with helm install to L2 (from L1)
 - **Development:**
   - Add script to check for newer requirements.txt package versions
 

--- a/docs/deployment/deploying.md
+++ b/docs/deployment/deploying.md
@@ -72,7 +72,7 @@ Once the values are set, install the helm chart with:
 ```sh
 helm repo add dragonchain https://dragonchain-charts.s3.amazonaws.com
 helm repo update
-helm upgrade --install my-dragonchain --values opensource-config.yaml --namespace dragonchain dragonchain/dragonchain-k8s --version 1.0.4
+helm upgrade --install my-dragonchain --values opensource-config.yaml --namespace dragonchain dragonchain/dragonchain-k8s --version 1.0.5
 ```
 
 If you need to change any values AFTER the helm chart has already been

--- a/dragonchain/lib/dao/block_dao.py
+++ b/dragonchain/lib/dao/block_dao.py
@@ -99,7 +99,8 @@ def insert_block(block: "model.BlockModel") -> None:
     #  Create ref to this block for the next block
     last_block_ref = {"block_id": block.block_id, "proof": block.proof}
     #  Upload stripped block
-    redisearch.put_document(redisearch.Indexes.block.value, block.block_id, block.export_as_search_index(), upsert=True)
+    if redisearch.ENABLED:
+        redisearch.put_document(redisearch.Indexes.block.value, block.block_id, block.export_as_search_index(), upsert=True)
     storage.put_object_as_json(f"{FOLDER}/{block.block_id}", block.export_as_at_rest())
 
     #  Upload ref

--- a/dragonchain/lib/database/redisearch.py
+++ b/dragonchain/lib/database/redisearch.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 _log = logger.get_logger()
 
 LEVEL = os.environ["LEVEL"]
+ENABLED = not (LEVEL != "1" and os.environ.get("USE_REDISEARCH") == "false")
 REDISEARCH_ENDPOINT = os.environ["REDISEARCH_ENDPOINT"]
 REDIS_PORT = int(os.environ["REDIS_PORT"]) or 6379
 
@@ -103,6 +104,8 @@ def _get_redisearch_index_client(index: str) -> redisearch.Client:
     """
     global _redis_connection
     if _redis_connection is None:
+        if not ENABLED:
+            raise RuntimeError("Redisearch was attempted to be used, but is disabled")
         _redis_connection = dragonchain_redis._initialize_redis(host=REDISEARCH_ENDPOINT, port=REDIS_PORT)
     return redisearch.Client(index, conn=_redis_connection)
 

--- a/dragonchain/lib/database/redisearch.py
+++ b/dragonchain/lib/database/redisearch.py
@@ -46,8 +46,9 @@ _log = logger.get_logger()
 
 LEVEL = os.environ["LEVEL"]
 ENABLED = not (LEVEL != "1" and os.environ.get("USE_REDISEARCH") == "false")
-REDISEARCH_ENDPOINT = os.environ["REDISEARCH_ENDPOINT"]
-REDIS_PORT = int(os.environ["REDIS_PORT"]) or 6379
+if ENABLED:
+    REDISEARCH_ENDPOINT = os.environ["REDISEARCH_ENDPOINT"]
+    REDIS_PORT = int(os.environ["REDIS_PORT"]) or 6379
 
 INDEX_GENERATION_KEY = "dc:index_generation_complete"
 BLOCK_MIGRATION_KEY = "dc:migrations:block"

--- a/dragonchain/transaction_processor/level_5_actions.py
+++ b/dragonchain/transaction_processor/level_5_actions.py
@@ -189,7 +189,8 @@ def broadcast_to_public_chain(l5_block: l5_block_model.L5BlockModel) -> None:
     storage_key = f"BLOCK/{l5_block.block_id}"
     _log.info(f"[L5] Adding to storage at {storage_key} and creating index")
     storage.put_object_as_json(storage_key, l5_block.export_as_at_rest())
-    redisearch.put_document(redisearch.Indexes.block.value, l5_block.block_id, l5_block.export_as_search_index(), upsert=True)
+    if redisearch.ENABLED:
+        redisearch.put_document(redisearch.Indexes.block.value, l5_block.block_id, l5_block.export_as_search_index(), upsert=True)
 
 
 def check_confirmations() -> None:

--- a/dragonchain/webserver/routes/blocks.py
+++ b/dragonchain/webserver/routes/blocks.py
@@ -22,11 +22,13 @@ import flask
 from dragonchain.webserver import helpers
 from dragonchain.webserver.lib import blocks
 from dragonchain.webserver import request_authorizer
+from dragonchain.lib.database import redisearch
 
 
 def apply_routes(app: flask.Flask):
-    app.add_url_rule("/block", "query_blocks_v1", query_blocks_v1, methods=["GET"])
-    app.add_url_rule("/v1/block", "query_blocks_v1", query_blocks_v1, methods=["GET"])
+    if redisearch.ENABLED:
+        app.add_url_rule("/block", "query_blocks_v1", query_blocks_v1, methods=["GET"])
+        app.add_url_rule("/v1/block", "query_blocks_v1", query_blocks_v1, methods=["GET"])
     app.add_url_rule("/block/<block_id>", "get_block_v1", get_block_v1, methods=["GET"])
     app.add_url_rule("/v1/block/<block_id>", "get_block_v1", get_block_v1, methods=["GET"])
 

--- a/dragonchain/webserver/routes/blocks.py
+++ b/dragonchain/webserver/routes/blocks.py
@@ -26,11 +26,11 @@ from dragonchain.lib.database import redisearch
 
 
 def apply_routes(app: flask.Flask):
+    app.add_url_rule("/block/<block_id>", "get_block_v1", get_block_v1, methods=["GET"])
+    app.add_url_rule("/v1/block/<block_id>", "get_block_v1", get_block_v1, methods=["GET"])
     if redisearch.ENABLED:
         app.add_url_rule("/block", "query_blocks_v1", query_blocks_v1, methods=["GET"])
         app.add_url_rule("/v1/block", "query_blocks_v1", query_blocks_v1, methods=["GET"])
-    app.add_url_rule("/block/<block_id>", "get_block_v1", get_block_v1, methods=["GET"])
-    app.add_url_rule("/v1/block/<block_id>", "get_block_v1", get_block_v1, methods=["GET"])
 
 
 @request_authorizer.Authenticated(api_resource="blocks", api_operation="read", api_name="get_block")

--- a/dragonchain/webserver/start.py
+++ b/dragonchain/webserver/start.py
@@ -49,15 +49,17 @@ def start() -> None:
         else:
             _log.info("HMAC key secret already exists. Skipping credential storage write.")
 
-    _log.info("Checking if redisearch indexes need to be regenerated")
-    redisearch.generate_indexes_if_necessary()
+    if redisearch.ENABLED:
+        _log.info("Checking if redisearch indexes need to be regenerated")
+        redisearch.generate_indexes_if_necessary()
 
     _log.info("Finish pre-boot successful")
 
 
 if __name__ == "__main__":
     # Wait for Redis and Redisearch to connect before starting initialization
-    redisearch._get_redisearch_index_client("test")
+    if redisearch.ENABLED:
+        redisearch._get_redisearch_index_client("test")
     redis._set_redis_client_if_necessary()
     redis._set_redis_client_lru_if_necessary()
     try:

--- a/helm/dragonchain-k8s/templates/configmap.yaml
+++ b/helm/dragonchain-k8s/templates/configmap.yaml
@@ -75,7 +75,7 @@ data:
     aof-load-truncated yes
     aof-use-rdb-preamble yes
 ---
-{{- if and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1")) }}
+{{- if not (and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1"))) }}
 # Redisearch Config Map
 apiVersion: v1
 kind: ConfigMap

--- a/helm/dragonchain-k8s/templates/configmap.yaml
+++ b/helm/dragonchain-k8s/templates/configmap.yaml
@@ -75,6 +75,7 @@ data:
     aof-load-truncated yes
     aof-use-rdb-preamble yes
 ---
+{{- if and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1")) }}
 # Redisearch Config Map
 apiVersion: v1
 kind: ConfigMap
@@ -107,6 +108,7 @@ data:
     aof-load-truncated yes
     aof-use-rdb-preamble yes
     loadmodule /usr/lib/redis/modules/redisearch.so TIMEOUT 2000 ON_TIMEOUT fail
+{{- end }}
 ---
 # Cache Redis Config Map
 apiVersion: v1

--- a/helm/dragonchain-k8s/templates/deployment.yaml
+++ b/helm/dragonchain-k8s/templates/deployment.yaml
@@ -652,7 +652,7 @@ spec:
             claimName: {{ .Release.Name }}-redis-volume
 
 ---
-{{- if and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1")) }}
+{{- if not (and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1"))) }}
 # Redisearch
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/dragonchain-k8s/templates/deployment.yaml
+++ b/helm/dragonchain-k8s/templates/deployment.yaml
@@ -652,6 +652,7 @@ spec:
             claimName: {{ .Release.Name }}-redis-volume
 
 ---
+{{- if and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1")) }}
 # Redisearch
 apiVersion: apps/v1
 kind: Deployment
@@ -723,3 +724,4 @@ spec:
         - name: storage
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-redisearch-volume
+{{- end }}

--- a/helm/dragonchain-k8s/templates/security.yaml
+++ b/helm/dragonchain-k8s/templates/security.yaml
@@ -27,7 +27,7 @@ spec:
       port: 8080
 
 ---
-{{- if and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1")) }}
+{{- if not (and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1"))) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/helm/dragonchain-k8s/templates/security.yaml
+++ b/helm/dragonchain-k8s/templates/security.yaml
@@ -27,6 +27,7 @@ spec:
       port: 8080
 
 ---
+{{- if and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1")) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -55,7 +56,7 @@ spec:
     ports:
     - protocol: TCP
       port: 6379
-
+{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/helm/dragonchain-k8s/templates/service.yaml
+++ b/helm/dragonchain-k8s/templates/service.yaml
@@ -75,7 +75,7 @@ spec:
     app.kubernetes.io/name: {{ .Release.Name }}-persistent-redis
     dragonchainId: {{ .Values.global.environment.INTERNAL_ID }}
 ---
-{{- if and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1")) }}
+{{- if not (and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1"))) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/dragonchain-k8s/templates/service.yaml
+++ b/helm/dragonchain-k8s/templates/service.yaml
@@ -75,6 +75,7 @@ spec:
     app.kubernetes.io/name: {{ .Release.Name }}-persistent-redis
     dragonchainId: {{ .Values.global.environment.INTERNAL_ID }}
 ---
+{{- if and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1")) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -98,3 +99,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ .Release.Name }}-redisearch
     dragonchainId: {{ .Values.global.environment.INTERNAL_ID }}
+{{- end }}

--- a/helm/dragonchain-k8s/templates/volumes.yaml
+++ b/helm/dragonchain-k8s/templates/volumes.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
 {{ toYaml .Values.redis.storage.spec | indent 2 }}
 ---
-{{- if and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1")) }}
+{{- if not (and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1"))) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/helm/dragonchain-k8s/templates/volumes.yaml
+++ b/helm/dragonchain-k8s/templates/volumes.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
 {{ toYaml .Values.redis.storage.spec | indent 2 }}
 ---
+{{- if and (eq .Values.global.environment.USE_REDISEARCH "false") (not (eq .Values.global.environment.LEVEL "1")) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -29,9 +30,9 @@ metadata:
     dragonchainId: {{ .Values.global.environment.INTERNAL_ID }}
 spec:
 {{ toYaml .Values.redisearch.storage.spec | indent 2 }}
-
-{{- if .Values.dragonchain.storage }}
+{{- end }}
 ---
+{{- if .Values.dragonchain.storage }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/helm/dragonchain-k8s/values.yaml
+++ b/helm/dragonchain-k8s/values.yaml
@@ -8,11 +8,11 @@ global:
     DRAGONCHAIN_ENDPOINT: "https://my-chain.api.company.org:443" # publicly accessible endpoint for this chain. MUST be able to be hit from the internet
     # If using a simple single node cluster like minikube, and the service values below are left as NodePort with port 30000, this would simply be 'http://public.ip.of.minikube.node:30000'
     # Remember to switch the protocol http:// or https:// depending on if you have enabled TLS support or not. (This can be any arbitrary string if no Dragon Net)
-    LEVEL: "1" # Integer 1-5 as a string. Must match with Dragon Net registration if participating in Dragon Net
-    TLS_SUPPORT: "" # Put 'true' here if you have created a TLS certificate and put into a tls kubernetes secret, otherwise leave empty
+    LEVEL: "2" # Integer 1-5 as a string. Must match with Dragon Net registration if participating in Dragon Net
+    TLS_SUPPORT: "" # Put "true" here if you have created a TLS certificate and put into a tls kubernetes secret, otherwise leave empty
     LOG_LEVEL: "debug"
-    USE_REDISEARCH: "true" # (l2+ only) Set to 'false' in order to disable redisearch functionality for a thinner node. Disables query endpoints
-    BROADCAST: "true" # Set to 'false' if you want to disable Dragon Net support
+    BROADCAST: "true" # Set to "false" if you want to disable Dragon Net support (L1 only)
+    USE_REDISEARCH: "false" # (l2+ only) Set to "true" in order to enable redisearch functionality (requires more cpu/memory). Enables query endpoints
     BROADCAST_INTERVAL: "2" # L5 ONLY! Number of hours between broadcasts to public chain
     STAGE: "prod"
     STORAGE_LOCATION: "/dragonchain"

--- a/helm/dragonchain-k8s/values.yaml
+++ b/helm/dragonchain-k8s/values.yaml
@@ -11,6 +11,7 @@ global:
     LEVEL: "1" # Integer 1-5 as a string. Must match with Dragon Net registration if participating in Dragon Net
     TLS_SUPPORT: "" # Put 'true' here if you have created a TLS certificate and put into a tls kubernetes secret, otherwise leave empty
     LOG_LEVEL: "debug"
+    USE_REDISEARCH: "true" # (l2+ only) Set to 'false' in order to disable redisearch functionality for a thinner node. Disables query endpoints
     BROADCAST: "true" # Set to 'false' if you want to disable Dragon Net support
     BROADCAST_INTERVAL: "2" # L5 ONLY! Number of hours between broadcasts to public chain
     STAGE: "prod"

--- a/helm/opensource-config.yaml
+++ b/helm/opensource-config.yaml
@@ -12,6 +12,7 @@ global:
     LEVEL: "1" # Integer 1-5 as a string. Must match with Dragon Net registration if participating in Dragon Net
     TLS_SUPPORT: "" # Put 'true' here if you have created a TLS certificate and put into a tls kubernetes secret, otherwise leave empty
     LOG_LEVEL: "debug"
+    USE_REDISEARCH: "true" # (l2+ only) Set to 'false' in order to disable redisearch functionality for a thinner node. Disables query endpoints
     BROADCAST: "true" # Set to 'false' if you want to disable Dragon Net support
 
 # -- isMinikube --

--- a/helm/opensource-config.yaml
+++ b/helm/opensource-config.yaml
@@ -9,15 +9,15 @@ global:
     DRAGONCHAIN_ENDPOINT: "https://my-chain.api.company.org:443" # publicly accessible endpoint for this chain. MUST be able to be hit from the internet
     # If using a simple single node cluster like minikube, and the service values below are left as NodePort with port 30000, this would simply be 'http://public.ip.of.minikube.node:30000'
     # Remember to switch the protocol http:// or https:// depending on if you have enabled TLS support or not. (This can be any arbitrary string if no Dragon Net)
-    LEVEL: "1" # Integer 1-5 as a string. Must match with Dragon Net registration if participating in Dragon Net
-    TLS_SUPPORT: "" # Put 'true' here if you have created a TLS certificate and put into a tls kubernetes secret, otherwise leave empty
+    LEVEL: "2" # Integer 1-5 as a string. Must match with Dragon Net registration if participating in Dragon Net
+    TLS_SUPPORT: "" # Put "true" here if you have created a TLS certificate and put into a tls kubernetes secret, otherwise leave empty
     LOG_LEVEL: "debug"
-    USE_REDISEARCH: "true" # (l2+ only) Set to 'false' in order to disable redisearch functionality for a thinner node. Disables query endpoints
-    BROADCAST: "true" # Set to 'false' if you want to disable Dragon Net support
+    BROADCAST: "true" # Set to "false" if you want to disable Dragon Net support (L1 only)
+    USE_REDISEARCH: "false" # (l2+ only) Set to "true" in order to enable redisearch functionality (requires more cpu/memory). Enables query endpoints
 
 # -- isMinikube --
-# When running on minikube this should be boolean true. otherwise boolean false.
-# This is mainly used in the redis configuration to adjust the somaxconn to a value minikube should use.
+# When running on minikube, this should be boolean true
+# This is mainly used in the redis configuration to adjust the somaxconn to a value minikube should use
 # I.e:
 # - name: net.core.somaxconn
 #     value: "1024"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==1.1.1
 requests==2.22.0
 fastjsonschema==2.14.1
 secp256k1==0.13.2
-web3==5.3.1
+web3==5.3.0
 kubernetes==10.0.1
 docker==4.1.0
 gunicorn[gevent]==20.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.10.32
+boto3==1.10.34
 redis==3.3.11
 apscheduler==3.6.3
 jsonpath==0.82
@@ -6,7 +6,7 @@ Flask==1.1.1
 requests==2.22.0
 fastjsonschema==2.14.1
 secp256k1==0.13.2
-web3==5.3.0
+web3==5.3.1
 kubernetes==10.0.1
 docker==4.1.0
 gunicorn[gevent]==20.0.4

--- a/scripts/check_packages.py
+++ b/scripts/check_packages.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import os
+import pathlib
+
+import requests
+
+try:
+    from packaging.version import parse
+except ImportError:
+    from pip._vendor.packaging.version import parse
+
+
+REQUIREMENTS_FILE = os.path.join(pathlib.Path(os.path.dirname(os.path.realpath(__file__))).parent, "requirements.txt")
+
+
+def get_version(package):
+    r = requests.get(f"https://pypi.python.org/pypi/{package}/json")
+    version = parse("0")
+    if r.status_code == 200:
+        response = r.json()
+        releases = response.get("releases", [])
+        for release in releases:
+            ver = parse(release)
+            if not ver.is_prerelease:
+                version = max(version, ver)
+    return version
+
+
+def get_requirements_packages():
+    packages = []
+    with open(REQUIREMENTS_FILE, "r") as f:
+        for line in f:
+            if line:
+                package = line[: line.find("==")]
+                version = line[line.find("==") + 2 :].rstrip()
+                if "[" in package:
+                    package = package[: package.find("[")]
+                packages.append((package, version))
+    return packages
+
+
+if __name__ == "__main__":
+    for package in get_requirements_packages():
+        latest_version = str(get_version(package[0]))
+        if latest_version != package[1]:
+            print(f"Newer stable version of {package[0]}: {latest_version}")

--- a/scripts/check_packages.py
+++ b/scripts/check_packages.py
@@ -11,16 +11,11 @@ except ImportError:
     from pip._vendor.packaging.version import parse
 
 
-REQUIREMENTS_FILE = os.path.join(pathlib.Path(os.path.dirname(os.path.realpath(__file__))).parent, "requirements.txt")
-
-
 def get_version(package):
     r = requests.get(f"https://pypi.python.org/pypi/{package}/json")
     version = parse("0")
     if r.status_code == 200:
-        response = r.json()
-        releases = response.get("releases", [])
-        for release in releases:
+        for release in r.json().get("releases", []):
             ver = parse(release)
             if not ver.is_prerelease:
                 version = max(version, ver)
@@ -29,11 +24,12 @@ def get_version(package):
 
 def get_requirements_packages():
     packages = []
-    with open(REQUIREMENTS_FILE, "r") as f:
+    with open(os.path.join(pathlib.Path(os.path.dirname(os.path.realpath(__file__))).parent, "requirements.txt"), "r") as f:
         for line in f:
+            line = line.rstrip()
             if line:
                 package = line[: line.find("==")]
-                version = line[line.find("==") + 2 :].rstrip()
+                version = line[line.find("==") + 2 :]
                 if "[" in package:
                     package = package[: package.find("[")]
                 packages.append((package, version))
@@ -44,4 +40,4 @@ if __name__ == "__main__":
     for package in get_requirements_packages():
         latest_version = str(get_version(package[0]))
         if latest_version != package[1]:
-            print(f"Newer stable version of {package[0]}: {latest_version}")
+            print(f"Newer version of {package[0]}: {latest_version}")


### PR DESCRIPTION
## Description

This PR makes redisearch an optional component for L2+ nodes.

If redisearch is disabled, then all query endpoints are also disabled. Re-enabling redisearch after being disabled will automatically backfill all indexes, so no data is lost if redisearch is accidentally disabled/deleted on a node.

Note that _by default_ with this update, redisearch is disabled, thus existing nodes that update with this code will have their redisearch disable unless they set the proper helm value when updating.

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] changelog has been modified for the changes
