### PR TITLE
Update status endpoint to indicate if indexing is on or off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Feature:**
   - Allow option for turning redisearch on/off with verification (L2+) nodes (and disable by default)
+  - Add field to status endpoint return to indicate if indexing (redisearch) is on/off
 - **Packaging:**
   - Update boto3, fastjsonschema, and web3 dependencies
   - Change default node level with helm install to L2 (from L1)

--- a/dragonchain/webserver/lib/misc.py
+++ b/dragonchain/webserver/lib/misc.py
@@ -21,6 +21,7 @@ from typing import Dict, Any
 from dragonchain import logger
 from dragonchain.lib import matchmaking
 from dragonchain.lib import keys
+from dragonchain.lib.database import redisearch
 
 _log = logger.get_logger()
 
@@ -35,6 +36,7 @@ def get_v1_status() -> Dict[str, Any]:
         "scheme": str(matchmaking_data["scheme"]),
         "version": str(matchmaking_data["version"]),
         "encryptionAlgo": str(matchmaking_data["encryptionAlgo"]),
+        "indexingEnabled": redisearch.ENABLED,
     }
     # Return extra data if level 5
     if os.environ["LEVEL"] == "5":

--- a/dragonchain/webserver/lib/misc_utest.py
+++ b/dragonchain/webserver/lib/misc_utest.py
@@ -1,0 +1,87 @@
+# Copyright 2019 Dragonchain, Inc.
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#      6. Trademarks. This License does not grant permission to use the trade
+#         names, trademarks, service marks, or product names of the Licensor
+#         and its affiliates, except as required to comply with Section 4(c) of
+#         the License and to reproduce the content of the NOTICE file.
+# You may obtain a copy of the Apache License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+
+import os
+import unittest
+from unittest.mock import patch
+
+from dragonchain import test_env  # noqa: F401
+from dragonchain.webserver.lib import misc
+
+
+class TestMisc(unittest.TestCase):
+    @patch("dragonchain.lib.keys.get_public_id")
+    @patch("dragonchain.lib.matchmaking.get_matchmaking_config")
+    def test_get_status_retrieves_matchmaking_data_and_id(self, mock_matchmaking, mock_get_id):
+        misc.get_v1_status()
+        mock_matchmaking.assert_called_once()
+        mock_get_id.assert_called_once()
+
+    @patch("dragonchain.lib.keys.get_public_id")
+    @patch("dragonchain.lib.matchmaking.get_matchmaking_config")
+    def test_get_status_returns_expected_dto_l1(self, mock_matchmaking, mock_get_id):
+        mock_matchmaking.return_value = {"level": "1", "url": "abc", "hashAlgo": "bcd", "scheme": "yup", "version": "1.2.3", "encryptionAlgo": "algo"}
+        mock_get_id.return_value = "my_id"
+        self.assertEqual(
+            misc.get_v1_status(),
+            {
+                "id": "my_id",
+                "level": 1,
+                "url": "abc",
+                "hashAlgo": "bcd",
+                "scheme": "yup",
+                "version": "1.2.3",
+                "encryptionAlgo": "algo",
+                "indexingEnabled": True,
+            },
+        )
+
+    @patch("dragonchain.lib.keys.get_public_id")
+    @patch("dragonchain.lib.matchmaking.get_matchmaking_config")
+    def test_get_status_returns_expected_dto_l5(self, mock_matchmaking, mock_get_id):
+        os.environ["LEVEL"] = "5"
+        mock_matchmaking.return_value = {
+            "level": "1",
+            "url": "abc",
+            "hashAlgo": "bcd",
+            "scheme": "yup",
+            "version": "1.2.3",
+            "encryptionAlgo": "algo",
+            "funded": True,
+            "broadcastInterval": "1.23",
+            "network": "net",
+            "interchainWallet": "0xabc",
+        }
+        mock_get_id.return_value = "my_id"
+        self.assertEqual(
+            misc.get_v1_status(),
+            {
+                "id": "my_id",
+                "level": 1,
+                "url": "abc",
+                "hashAlgo": "bcd",
+                "scheme": "yup",
+                "version": "1.2.3",
+                "encryptionAlgo": "algo",
+                "indexingEnabled": True,
+                "funded": True,
+                "broadcastInterval": 1.23,
+                "network": "net",
+                "interchainWallet": "0xabc",
+            },
+        )
+        os.environ["LEVEL"] = "1"


### PR DESCRIPTION
## Description

Adds a new `indexingEnabled` response field to the get status endpoint which indicates if redisearch is on or off

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] tests are included
- [x] changelog has been modified for the changes
