### PR TITLE
Allow updating smart contract api keys, and remove 'reserved' key concept from WEB_ keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Feature:**
   - Add field to status endpoint return to indicate if indexing (redisearch) is on/off
+  - Allow get/list/update on smart contract api keys (allowing their permissions to be viewed/changed)
 - **Documentation:**
   - Edit notes about ram usage requirements for Dragonchain
 - **Packaging:**
@@ -18,6 +19,7 @@
 - **Development:**
   - Add script to check for newer requirements.txt package versions
   - Implemented deadlines for L5 blocks based on block times and confirmations for public blockchains
+  - Remove any concept of api keys starting with `WEB_` from being special
 
 ## 4.3.0
 

--- a/dragonchain/lib/dao/api_key_dao.py
+++ b/dragonchain/lib/dao/api_key_dao.py
@@ -61,10 +61,9 @@ def list_api_keys(include_interchain: bool) -> List[api_key_model.APIKeyModel]:
     # Get keys from storage, excluding migration marker and interchain keys
     return_list = []
     for key in storage.list_objects(prefix=FOLDER):
-        if MIGRATION_V1 not in key:
-            if key.startswith("KEYS/INTERCHAIN") and not include_interchain:
-                continue
-            return_list.append(api_key_model.new_from_at_rest(storage.get_json_from_object(key)))
+        if (MIGRATION_V1 in key) or (key.startswith("KEYS/INTERCHAIN") and not include_interchain):
+            continue
+        return_list.append(api_key_model.new_from_at_rest(storage.get_json_from_object(key)))
     return return_list
 
 

--- a/dragonchain/lib/dao/api_key_dao_utest.py
+++ b/dragonchain/lib/dao/api_key_dao_utest.py
@@ -37,30 +37,9 @@ class TestApiKeyDAO(unittest.TestCase):
             "nickname": "",
         },
     )
-    @patch("dragonchain.lib.dao.api_key_dao.storage.list_objects", return_value=["KEYS/SC_blah", "KEYS/WEB_blah", "KEYS/blah"])
-    def test_list_api_keys_removes_system_keys(self, mock_list_objects, mock_get_object):
-        response = api_key_dao.list_api_keys(include_interchain=False, include_system=False)
-        self.assertEqual(len(response), 1)
-        self.assertEqual(response[0].key_id, "blah")
-        self.assertEqual(response[0].registration_time, 1234)
-        mock_get_object.assert_called_once()
-
-    @patch(
-        "dragonchain.lib.dao.api_key_dao.storage.get_json_from_object",
-        return_value={
-            "key_id": "blah",
-            "registration_time": 1234,
-            "key": "my_auth_key",
-            "version": "1",
-            "permissions_document": {"version": "1", "default_allow": True, "permissions": {}},
-            "interchain": False,
-            "root": False,
-            "nickname": "",
-        },
-    )
     @patch("dragonchain.lib.dao.api_key_dao.storage.list_objects", return_value=["KEYS/INTERCHAIN/blah", "KEYS/blah"])
     def test_list_api_keys_removes_interchain_keys(self, mock_list_objects, mock_get_object):
-        response = api_key_dao.list_api_keys(include_interchain=False, include_system=True)
+        response = api_key_dao.list_api_keys(include_interchain=False)
         self.assertEqual(len(response), 1)
         self.assertEqual(response[0].key_id, "blah")
         self.assertEqual(response[0].registration_time, 1234)
@@ -81,7 +60,7 @@ class TestApiKeyDAO(unittest.TestCase):
     )
     @patch("dragonchain.lib.dao.api_key_dao.storage.list_objects", return_value=["KEYS/INTERCHAIN/blah"])
     def test_list_api_keys_include_interchain_keys(self, mock_list_objects, mock_get_object):
-        response = api_key_dao.list_api_keys(include_interchain=True, include_system=True)
+        response = api_key_dao.list_api_keys(include_interchain=True)
         self.assertEqual(len(response), 1)
         self.assertEqual(response[0].key_id, "blah")
         self.assertEqual(response[0].registration_time, 1234)
@@ -102,7 +81,7 @@ class TestApiKeyDAO(unittest.TestCase):
     )
     @patch("dragonchain.lib.dao.api_key_dao.storage.list_objects", return_value=["KEYS/blah", "KEYS/INTERCHAIN/blah"])
     def test_list_api_key_raises_error_when_mismatching_interchain(self, mock_list_objects, mock_get_object):
-        self.assertRaises(RuntimeError, api_key_dao.list_api_keys, include_interchain=True, include_system=True)
+        self.assertRaises(RuntimeError, api_key_dao.list_api_keys, include_interchain=True)
         mock_get_object.return_value = {
             "key_id": "blah",
             "registration_time": 1234,
@@ -114,7 +93,7 @@ class TestApiKeyDAO(unittest.TestCase):
             "nickname": "",
         }
 
-        self.assertRaises(RuntimeError, api_key_dao.list_api_keys, include_interchain=False, include_system=True)
+        self.assertRaises(RuntimeError, api_key_dao.list_api_keys, include_interchain=False)
 
     @patch("dragonchain.lib.dao.api_key_dao.storage.put_object_as_json")
     def test_save_api_key_calls_storage_correctly(self, mock_save):

--- a/dragonchain/lib/dao/api_key_dao_utest.py
+++ b/dragonchain/lib/dao/api_key_dao_utest.py
@@ -66,35 +66,6 @@ class TestApiKeyDAO(unittest.TestCase):
         self.assertEqual(response[0].registration_time, 1234)
         mock_get_object.assert_called_once()
 
-    @patch(
-        "dragonchain.lib.dao.api_key_dao.storage.get_json_from_object",
-        return_value={
-            "key_id": "blah",
-            "registration_time": 1234,
-            "key": "my_auth_key",
-            "version": "1",
-            "permissions_document": {"version": "1", "default_allow": True, "permissions": {}},
-            "interchain": False,
-            "root": False,
-            "nickname": "",
-        },
-    )
-    @patch("dragonchain.lib.dao.api_key_dao.storage.list_objects", return_value=["KEYS/blah", "KEYS/INTERCHAIN/blah"])
-    def test_list_api_key_raises_error_when_mismatching_interchain(self, mock_list_objects, mock_get_object):
-        self.assertRaises(RuntimeError, api_key_dao.list_api_keys, include_interchain=True)
-        mock_get_object.return_value = {
-            "key_id": "blah",
-            "registration_time": 1234,
-            "key": "my_auth_key",
-            "version": "1",
-            "permissions_document": {"version": "1", "default_allow": True, "permissions": {}},
-            "interchain": True,
-            "root": False,
-            "nickname": "",
-        }
-
-        self.assertRaises(RuntimeError, api_key_dao.list_api_keys, include_interchain=False)
-
     @patch("dragonchain.lib.dao.api_key_dao.storage.put_object_as_json")
     def test_save_api_key_calls_storage_correctly(self, mock_save):
         fake_api_key = MagicMock()

--- a/dragonchain/lib/dao/api_key_dao_utest.py
+++ b/dragonchain/lib/dao/api_key_dao_utest.py
@@ -132,6 +132,9 @@ class TestApiKeyDAO(unittest.TestCase):
         api_key_dao.delete_api_key("notinterchain", interchain=False)
         mock_delete.assert_has_calls([call("KEYS/INTERCHAIN/interchain"), call("KEYS/notinterchain")])
 
+    def test_delete_api_key_throws_error_if_deleting_interchain_key_when_not_intended(self):
+        self.assertRaises(RuntimeError, api_key_dao.delete_api_key, "INTERCHAIN/malicious", False)
+
     @patch("dragonchain.lib.dao.api_key_dao.storage.list_objects")
     @patch("dragonchain.lib.dao.api_key_dao.storage.get", return_value=b"1")
     def test_perform_api_key_migration_doesnt_do_anything_when_already_migrated(self, mock_get, mock_list):

--- a/dragonchain/webserver/lib/api_keys.py
+++ b/dragonchain/webserver/lib/api_keys.py
@@ -47,7 +47,7 @@ def get_api_key_list_v1() -> Dict[str, List[Dict[str, Any]]]:
     Returns:
         List of API keys
     """
-    keys = api_key_dao.list_api_keys(include_interchain=False, include_system=False)
+    keys = api_key_dao.list_api_keys(include_interchain=False)
     returned_keys = []
     for key in keys:
         returned_keys.append(_api_key_model_to_user_dto(key))
@@ -73,8 +73,8 @@ def delete_api_key_v1(key_id: str) -> None:
         key_id: ID of api key to delete
     """
     # Don't allow removal of reserved keys
-    if key_id.startswith("SC_") or key_id.startswith("INTERCHAIN") or key_id.startswith("WEB_"):
-        raise exceptions.ActionForbidden("cannot delete reserved API keys")
+    if key_id.startswith("SC_") or key_id.startswith("INTERCHAIN"):
+        raise exceptions.ActionForbidden("Cannot delete reserved API keys")
     # Don't allow removal of root keys
     if secrets.get_dc_secret("hmac-id") == key_id:
         raise exceptions.ActionForbidden("Cannot remove root API key")
@@ -90,8 +90,8 @@ def get_api_key_v1(key_id: str) -> Dict[str, Any]:
     Returns:
         API key ID and registration timestamp (if any)
     """
-    if key_id.startswith("SC_") or key_id.startswith("WEB_") or key_id.startswith("INTERCHAIN"):
-        raise exceptions.NotFound("Cannot get reserved api key")
+    if key_id.startswith("INTERCHAIN"):
+        raise exceptions.NotFound("Cannot get interchain api keys")
     return _api_key_model_to_user_dto(api_key_dao.get_api_key(key_id, interchain=False))
 
 
@@ -101,8 +101,8 @@ def update_api_key_v1(key_id: str, nickname: Optional[str] = None, permissions_d
         key_id: ID of api key to update
         nickname: new nickname for the given key
     """
-    if key_id.startswith("SC_") or key_id.startswith("WEB_") or key_id.startswith("INTERCHAIN"):
-        raise exceptions.ActionForbidden("Cannot modify reserved keys")
+    if key_id.startswith("INTERCHAIN"):
+        raise exceptions.ActionForbidden("Cannot modify interchain keys")
     key = api_key_dao.get_api_key(key_id, interchain=False)
     if nickname:
         key.nickname = nickname

--- a/dragonchain/webserver/lib/api_keys_utest.py
+++ b/dragonchain/webserver/lib/api_keys_utest.py
@@ -32,7 +32,7 @@ class TestApiKeyLib(unittest.TestCase):
         self.assertEqual(len(response), 1)
         self.assertEqual(response[0]["id"], "blah")
         self.assertEqual(response[0]["registration_time"], 1234)
-        mock_list_keys.assert_called_once_with(include_interchain=False, include_system=False)
+        mock_list_keys.assert_called_once_with(include_interchain=False)
 
     @patch("dragonchain.webserver.lib.api_keys.api_key_model.new_from_scratch")
     @patch("dragonchain.webserver.lib.api_keys.api_key_dao.save_api_key")
@@ -65,14 +65,8 @@ class TestApiKeyLib(unittest.TestCase):
         api_keys.delete_api_key_v1("1")
         mock_delete_api_key.assert_called_once_with(key_id="1", interchain=False)
 
-    def test_get_api_key_raises_not_found_when_sc_key(self):
-        self.assertRaises(exceptions.NotFound, api_keys.get_api_key_v1, "SC_key")
-
     def test_get_api_key_raises_not_found_when_interchain_key(self):
         self.assertRaises(exceptions.NotFound, api_keys.get_api_key_v1, "INTERCHAIN/ic_key")
-
-    def test_get_api_key_raises_not_found_when_web_key(self):
-        self.assertRaises(exceptions.NotFound, api_keys.get_api_key_v1, "WEB_key")
 
     @patch("dragonchain.webserver.lib.api_keys.api_key_dao.get_api_key")
     def test_get_api_key_calls_appropriately(self, mock_get_key):
@@ -82,8 +76,6 @@ class TestApiKeyLib(unittest.TestCase):
         self.assertEqual(response["registration_time"], mock_get_key.return_value.registration_time)
 
     def test_update_api_key_raises_forbidden_when_key_id_starts_with_reserved_sequence(self):
-        self.assertRaises(exceptions.ActionForbidden, api_keys.update_api_key_v1, "SC_thing")
-        self.assertRaises(exceptions.ActionForbidden, api_keys.update_api_key_v1, "WEB_thing")
         self.assertRaises(exceptions.ActionForbidden, api_keys.update_api_key_v1, "INTERCHAIN/whatever")
 
     @patch("dragonchain.webserver.lib.api_keys.api_key_dao.get_api_key")


### PR DESCRIPTION
## Description

Smart contract api keys were unable to have any permissions except the default permissions, so this update allows a smart contract api key to be updated (and listed/viewed).

Additionally this PR removes the concept of an api key starting with WEB_ from being reserved; This used to be an old concept for the managed dragonchain service, but has not been used for a while.

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] tests are included
- [x] changelog has been modified for the changes
