### PR TITLE
Deprecate morden and add raspi docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Restrict contract create/update schema to deny overwriting reserved 'secret-key' and 'auth-key-id' secrets
 - **Documentation:**
   - Edit notes about ram usage requirements for Dragonchain
+  - Add documentation for deploying with a raspberry pi
 - **Packaging:**
   - Update boto3, fastjsonschema, and web3 dependencies
   - Change default node level with helm install to L2 (from L1)
@@ -23,6 +24,7 @@
   - Add script to check for newer requirements.txt package versions
   - Implemented deadlines for L5 blocks based on block times and confirmations for public blockchains
   - Remove any concept of api keys starting with `WEB_` from being special
+  - Deprecate support for Ethereum Classic Testnet (Morden) with ethereum interchain functionality
 
 ## 4.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - Provide multiarch (arm64/amd64) manifests for built containers in dockerhub
   - Update redisearch in helm chart to 1.4.19
   - Tweak pod resource usages in helm chart for lower requirements
+  - Update fwatchdog to 0.18.7 for OpenFaaS smart contracts
 - **CICD:**
   - Add building for arm64 containers (in addition to existing amd64)
 - **Development:**

--- a/docs/deployment/raspberry_pi.md
+++ b/docs/deployment/raspberry_pi.md
@@ -7,7 +7,7 @@ Although all of the Dragonchain code supports running on ARM, redisearch does
 not run on ARM, so any chain with a redisearch will not be able to run on a
 raspberry pi.
 
-With that said, all chains L2+ only optionally require redisearch, and are
+With that said, verification nodes (L2-5) do not require redisearch and are
 deployed without a redisearch by default, so the existing helm chart fully
 supports deploying onto a kubernetes cluster running on an ARM machine such as
 as raspberry pi.

--- a/docs/deployment/raspberry_pi.md
+++ b/docs/deployment/raspberry_pi.md
@@ -1,0 +1,56 @@
+# Running On A Raspberry Pi
+
+Dragonchain has ARM64 builds of its docker container to support running on ARM
+devices such as the raspberry pi.
+
+Although all of the Dragonchain code supports running on ARM, redisearch does
+not run on ARM, so any chain with a redisearch will not be able to run on a
+raspberry pi.
+
+With that said, all chains L2+ only optionally require redisearch, and are
+deployed without a redisearch by default, so the existing helm chart fully
+supports deploying onto a kubernetes cluster running on an ARM machine such as
+as raspberry pi.
+
+## Requirements
+
+Currently, because Dragonchain requires kubernetes, and does not yet run on
+something lighter weight for a single deployment (such as docker compose), a
+kubernetes cluster is required to run Dragonchain.
+
+Running a lightweight kubernetes distribution on a raspberry pi (such as
+[k3s](https://k3s.io/) or [microk8s](https://microk8s.io/)) ends up using
+around ~500MB of RAM, on top of the OS. This means that before Dragonchain is
+deployed, around ~750MB of RAM is used just by linux/kubernetes.
+
+Unfortunately, this means that Dragonchain will currently only run on a
+raspberry pi with **2GB or more of total RAM**. Currently the only devices that
+support this are the raspberry pi model 4 in either the 2 or 4GB variant.
+
+Also note that you must install a 64 bit OS onto your raspberry pi. Raspbian
+_**is not**_ currently a 64 bit operating system, so installing an alternative
+such as
+[ubuntu's 64bit raspberry pi distribution](https://ubuntu.com/download/raspberry-pi)
+is required.
+
+## Installing Dragonchain
+
+All of the previous docs still apply to deploying a dragonchain on a raspberry
+pi, with the exception that only L2+ chains are supported.
+
+Additionally, when deploying the helm chart, some cpu resource limits should
+be increased in order to compensate for the lower performance of the device's
+CPU.
+
+These limits are commented out at the bottom of the available
+`opensource-config.yaml` from the previous deployment docs.
+
+Alternatively, simply add this flag to your `helm upgrade` or `helm install`
+command when installing dragonchain:
+
+```sh
+--set cacheredis.resources.limits.cpu=1,persistentredis.resources.limits.cpu=1,webserver.resources.limits.cpu=1,transactionProcessor.resources.limits.cpu=1
+```
+
+Other than that change, no other changes should be required in order to have
+Dragonchain running on a Raspberry pi.

--- a/docs/deployment/raspberry_pi.md
+++ b/docs/deployment/raspberry_pi.md
@@ -42,8 +42,8 @@ Additionally, when deploying the helm chart, some cpu resource limits should
 be increased in order to compensate for the lower performance of the device's
 CPU.
 
-These limits are commented out at the bottom of the available
-`opensource-config.yaml` from the previous deployment docs.
+These suggested limits are provided, commented out, at the bottom of the
+available `opensource-config.yaml` from the previous deployment docs.
 
 Alternatively, simply add this flag to your `helm upgrade` or `helm install`
 command when installing dragonchain:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ All of the source code, as well as issue tracker can be viewed `on github <https
    deployment/dragonnet
    deployment/deploying
    deployment/links
+   deployment/raspberry_pi
    deployment/migrating_v4
 
 .. toctree::

--- a/dragonchain/job_processor/contract_job.py
+++ b/dragonchain/job_processor/contract_job.py
@@ -210,7 +210,7 @@ class ContractJob(object):
                 "com.openfaas.scale.max": "20",
                 "com.openfaas.scale.factor": "20",
                 "com.dragonchain.id": INTERNAL_ID,
-                "com.openfaas.fwatchdog.version": "0.18.4",  # Update this as the fwatchdog executable in bin is updates
+                "com.openfaas.fwatchdog.version": "0.18.7",  # Update this as the fwatchdog executable in bin is updates
             },
             "limits": {"cpu": "0.50", "memory": "600M"},
             "requests": {"cpu": "0.25", "memory": "600M"},

--- a/dragonchain/job_processor/contract_job_utest.py
+++ b/dragonchain/job_processor/contract_job_utest.py
@@ -223,7 +223,7 @@ class ContractJobTest(unittest.TestCase):
                     "com.openfaas.scale.factor": "20",
                     "com.openfaas.scale.max": "20",
                     "com.openfaas.scale.min": "1",
-                    "com.openfaas.fwatchdog.version": "0.18.4",
+                    "com.openfaas.fwatchdog.version": "0.18.7",
                 },
                 "limits": {"cpu": "0.50", "memory": "600M"},
                 "requests": {"cpu": "0.25", "memory": "600M"},

--- a/dragonchain/lib/dto/eth.py
+++ b/dragonchain/lib/dto/eth.py
@@ -33,8 +33,6 @@ DRAGONCHAIN_MAINNET_NODE = "http://internal-Parity-Mainnet-Internal-1844666982.u
 DRAGONCHAIN_ROPSTEN_NODE = "http://internal-Parity-Ropsten-Internal-1699752391.us-west-2.elb.amazonaws.com:8545"
 # Mainnet ETC
 DRAGONCHAIN_CLASSIC_NODE = "http://internal-Parity-Classic-Internal-2003699904.us-west-2.elb.amazonaws.com:8545"
-# Testnet ETC
-DRAGONCHAIN_MORDEN_NODE = "http://internal-Parity-Morden-Internal-26081757.us-west-2.elb.amazonaws.com:8545"
 
 AVERAGE_BLOCK_TIME = 15  # in seconds
 CONFIRMATIONS_CONSIDERED_FINAL = 12
@@ -76,11 +74,9 @@ def new_from_user_input(user_input: Dict[str, Any]) -> "EthereumNetwork":  # noq
                 user_input["rpc_address"] = DRAGONCHAIN_ROPSTEN_NODE
             elif user_input.get("chain_id") == 61:
                 user_input["rpc_address"] = DRAGONCHAIN_CLASSIC_NODE
-            elif user_input.get("chain_id") == 62:
-                user_input["rpc_address"] = DRAGONCHAIN_MORDEN_NODE
             else:
                 raise exceptions.BadRequest(
-                    "If an rpc address is not provided, a valid chain id must be provided. ETH_MAIN = 1, ETH_ROPSTEN = 3, ETC_MAIN = 61, ETC_MORDEN = 62"
+                    "If an rpc address is not provided, a valid chain id must be provided. ETH_MAIN = 1, ETH_ROPSTEN = 3, ETC_MAIN = 61"
                 )
         # Create our client with a still undetermined chain id
         try:
@@ -95,9 +91,9 @@ def new_from_user_input(user_input: Dict[str, Any]) -> "EthereumNetwork":  # noq
         except Exception as e:
             raise exceptions.BadRequest(f"Error trying to contact ethereum rpc node. Error: {e}")
         effective_chain_id = user_input.get("chain_id")
-        # For ethereum classic, the mainnet/testnet nodes are chain ID 1/2, however their transactions
-        # must be signed with chain id 61/62, so we have an exception here for the chain id sanity check
-        if effective_chain_id == 61 or effective_chain_id == 62:
+        # For ethereum classic, the mainnet node is chain ID 1, however its transactions
+        # must be signed with chain id 61, so we have an exception here for the chain id sanity check
+        if effective_chain_id == 61:
             effective_chain_id -= 60
         # Sanity check if user provided chain id that it matches the what the RPC node reports
         if isinstance(effective_chain_id, int) and effective_chain_id != reported_chain_id:

--- a/dragonchain/lib/dto/eth_utest.py
+++ b/dragonchain/lib/dto/eth_utest.py
@@ -166,10 +166,6 @@ class TestEthereumMethods(unittest.TestCase):
         client = eth.new_from_user_input({"version": "1", "name": "banana", "chain_id": 61})
         self.assertEqual(client.rpc_address, "http://internal-Parity-Classic-Internal-2003699904.us-west-2.elb.amazonaws.com:8545")
         self.assertEqual(client.chain_id, 61)  # Ensure the chain id for ETC mainnet is correct
-        mock_check_chain_id.return_value = 2
-        client = eth.new_from_user_input({"version": "1", "name": "banana", "chain_id": 62})
-        self.assertEqual(client.rpc_address, "http://internal-Parity-Morden-Internal-26081757.us-west-2.elb.amazonaws.com:8545")
-        self.assertEqual(client.chain_id, 62)  # Ensure the chain id for ETC testnet is correct
 
     @patch("dragonchain.lib.dto.eth.EthereumNetwork.check_rpc_chain_id", return_value=1)
     def test_new_from_user_input_sets_good_private_keys(self, mock_check_chain_id):

--- a/dragonchain/webserver/lib/interchain.py
+++ b/dragonchain/webserver/lib/interchain.py
@@ -190,7 +190,6 @@ def legacy_get_blockchain_addresses_v1() -> Dict[str, str]:
         "eth_mainnet": interchain_dao.get_interchain_client("ethereum", "ETH_MAINNET").address,
         "eth_ropsten": interchain_dao.get_interchain_client("ethereum", "ETH_ROPSTEN").address,
         "etc_mainnet": interchain_dao.get_interchain_client("ethereum", "ETC_MAINNET").address,
-        "etc_morden": interchain_dao.get_interchain_client("ethereum", "ETC_MORDEN").address,
         "btc_mainnet": interchain_dao.get_interchain_client("bitcoin", "BTC_MAINNET").address,
         "btc_testnet3": interchain_dao.get_interchain_client("bitcoin", "BTC_TESTNET3").address,
     }

--- a/dragonchain/webserver/routes/interchain.py
+++ b/dragonchain/webserver/routes/interchain.py
@@ -248,7 +248,7 @@ def public_blockchain_transaction_v1(**kwargs) -> Tuple[str, int, Dict[str, str]
     try:
         if data["network"] in ["BTC_MAINNET", "BTC_TESTNET3"]:
             _validate_bitcoin_transaction_v1(data.get("transaction"))
-        elif data["network"] in ["ETH_MAINNET", "ETH_ROPSTEN", "ETC_MAINNET", "ETC_MORDEN"]:
+        elif data["network"] in ["ETH_MAINNET", "ETH_ROPSTEN", "ETC_MAINNET"]:
             _validate_ethereum_transaction_v1(data.get("transaction"))
         else:
             raise exceptions.ValidationException("Invalid network provided")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.10.38
+boto3==1.10.43
 redis==3.3.11
 apscheduler==3.6.3
 jsonpath==0.82


### PR DESCRIPTION
## Description

This PR deprecates support for the ethereum classic testnet (Morden), which is no longer used by the ethereum classic community.

It also adds docs about deploying dragonchain to a raspberry pi.

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] documentation is changed or added
- [x] changelog has been modified for the changes
