### PR TITLE
Add recovery queue and brpoplpush to job processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
   - Implemented deadlines for L5 blocks based on block times and confirmations for public blockchains
   - Remove any concept of api keys starting with `WEB_` from being special
   - Deprecate support for Ethereum Classic Testnet (Morden) with ethereum interchain functionality
+  - Add retry logic to catch failed job processor jobs
 
 ## 4.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Fix tests for python 3.8.1
 - **Bugs:**
   - Adds Content-Type header to all verification notifications
+  - Add retry logic to catch failed job processor jobs
 
 ## 4.3.2
 
@@ -48,7 +49,6 @@
   - Implemented deadlines for L5 blocks based on block times and confirmations for public blockchains
   - Remove any concept of api keys starting with `WEB_` from being special
   - Deprecate support for Ethereum Classic Testnet (Morden) with ethereum interchain functionality
-  - Add retry logic to catch failed job processor jobs
 
 ## 4.3.0
 

--- a/dragonchain/job_processor/job_processor.py
+++ b/dragonchain/job_processor/job_processor.py
@@ -120,7 +120,6 @@ def get_next_task() -> Optional[dict]:
     _log.info("Awaiting contract task...")
     pop_result = redis.brpoplpush_sync(CONTRACT_TASK_KEY, PENDING_TASK_KEY, 0, decode=False)
     if pop_result is None:
-        redis.lpop_sync(PENDING_TASK_KEY)
         return None
     _, event = pop_result
     _log.debug(f"received task: {event}")
@@ -129,6 +128,7 @@ def get_next_task() -> Optional[dict]:
         _validate_sc_build_task(event)
     except Exception:
         _log.exception("Error processing task, skipping")
+        redis.lpop_sync(PENDING_TASK_KEY)
         return None
     _log.info(f"New task request received: {event}")
     return event

--- a/dragonchain/job_processor/job_processor.py
+++ b/dragonchain/job_processor/job_processor.py
@@ -40,6 +40,9 @@ STORAGE_LOCATION = os.environ["STORAGE_LOCATION"]
 SECRET_LOCATION = os.environ["SECRET_LOCATION"]
 DRAGONCHAIN_IMAGE = os.environ["DRAGONCHAIN_IMAGE"]
 
+CONTRACT_TASK_KEY = "mq:contract-task"
+PENDING_TASK_KEY = "mq:contract-pending"
+
 _log = logger.get_logger()
 _kube: kubernetes.client.BatchV1Api = cast(kubernetes.client.BatchV1Api, None)  # This will always be defined before starting by being set in start()
 _validate_sc_build_task = fastjsonschema.compile(schema.smart_contract_build_task_schema)
@@ -55,6 +58,14 @@ def start() -> None:
     _kube = kubernetes.client.BatchV1Api()
 
     _log.debug("Job processor ready!")
+
+    if redis.llen_sync(PENDING_TASK_KEY):
+        _log.warning("WARNING! Pending job processor queue was not empty. Last job probably crashed. Re-queueing these dropped items.")
+        to_recover = redis.lrange_sync(PENDING_TASK_KEY, 0, -1, decode=False)
+        p = redis.pipeline_sync()
+        p.rpush(CONTRACT_TASK_KEY, *to_recover)
+        p.delete(PENDING_TASK_KEY)
+        p.execute()
     while True:
         start_task()
 
@@ -105,7 +116,7 @@ def get_next_task() -> Optional[dict]:
         The next task. Blocks until a job is found.
     """
     _log.info("Awaiting contract task...")
-    pop_result = redis.brpop_sync("mq:contract-task", 0, decode=False)
+    pop_result = redis.brpoplpush_sync(CONTRACT_TASK_KEY, PENDING_TASK_KEY, 0, decode=False)
     if pop_result is None:
         return None
     _, event = pop_result
@@ -117,6 +128,7 @@ def get_next_task() -> Optional[dict]:
         _log.exception("Error processing task, skipping")
         return None
     _log.info(f"New task request received: {event}")
+    redis.lpop_sync(PENDING_TASK_KEY)
     return event
 
 

--- a/dragonchain/job_processor/job_processor.py
+++ b/dragonchain/job_processor/job_processor.py
@@ -108,6 +108,7 @@ def start_task() -> None:
         if job and (job.status.succeeded or job.status.failed):
             delete_existing_job(task_definition)
         attempt_job_launch(task_definition)
+        redis.lpop_sync(PENDING_TASK_KEY)
 
 
 def get_next_task() -> Optional[dict]:
@@ -128,7 +129,6 @@ def get_next_task() -> Optional[dict]:
         _log.exception("Error processing task, skipping")
         return None
     _log.info(f"New task request received: {event}")
-    redis.lpop_sync(PENDING_TASK_KEY)
     return event
 
 

--- a/dragonchain/job_processor/job_processor_utest.py
+++ b/dragonchain/job_processor/job_processor_utest.py
@@ -75,7 +75,7 @@ class TestJobPoller(unittest.TestCase):
             mock_start_task.assert_called_once()
             mock_pipeline.assert_called_once()
             return
-        self.fail('Should have had an exception, honestly not sure how you got here')
+        self.fail("Should have had an exception, honestly not sure how you got here")
 
     @patch("dragonchain.job_processor.job_processor.redis.brpoplpush_sync", return_value=(1, valid_task_definition_string))
     def test_can_get_next_task(self, mock_brpoplpush):

--- a/dragonchain/job_processor/job_processor_utest.py
+++ b/dragonchain/job_processor/job_processor_utest.py
@@ -162,19 +162,21 @@ class TestJobPoller(unittest.TestCase):
         mock_job_launch.assert_called_once_with(valid_task_definition)
         mock_lpopsync.assert_called_once()
 
+    @patch("dragonchain.job_processor.job_processor.redis.lpop_sync")
     @patch("dragonchain.job_processor.job_processor.get_next_task", return_value=valid_task_definition)
     @patch(
         "dragonchain.job_processor.job_processor.get_existing_job_status", return_value=MagicMock(status=MagicMock(active=1, succeeded=0, failed=0))
     )
     @patch("dragonchain.job_processor.job_processor.delete_existing_job")
     @patch("dragonchain.job_processor.job_processor.attempt_job_launch")
-    def test_start_task_no_ops_when_running_job(self, mock_job_launch, mock_delete_job, mock_get_job, mock_get_task):
+    def test_start_task_no_ops_when_running_job(self, mock_job_launch, mock_delete_job, mock_get_job, mock_get_task, mock_lpop):
         job_processor.start_task()
 
         mock_get_task.assert_called_once_with()
         mock_get_job.assert_called_once_with(valid_task_definition)
         mock_delete_job.assert_not_called()
         mock_job_launch.assert_not_called()
+        mock_lpop.assert_called_once()
 
     def test_attempt_job_launch_raises_on_too_many_retries(self):
         self.assertRaises(RuntimeError, job_processor.attempt_job_launch, valid_task_definition, retry=6)

--- a/dragonchain/job_processor/job_processor_utest.py
+++ b/dragonchain/job_processor/job_processor_utest.py
@@ -69,11 +69,13 @@ class TestJobPoller(unittest.TestCase):
         try:
             job_processor.start()
         except Exception:
-            pass  # catch exception to allow the start method to ever exit
-        mock_redis_llen.assert_called_once_with("mq:contract-pending")
-        mock_lrange.assert_called_once_with("mq:contract-pending", 0, -1, decode=False)
-        mock_start_task.assert_called_once()
-        mock_pipeline.assert_called_once()
+            # catch exception to allow the start method to ever exit
+            mock_redis_llen.assert_called_once_with("mq:contract-pending")
+            mock_lrange.assert_called_once_with("mq:contract-pending", 0, -1, decode=False)
+            mock_start_task.assert_called_once()
+            mock_pipeline.assert_called_once()
+            return
+        self.fail('Should have had an exception, honestly not sure how you got here')
 
     @patch("dragonchain.job_processor.job_processor.redis.brpoplpush_sync", return_value=(1, valid_task_definition_string))
     def test_can_get_next_task(self, mock_brpoplpush):

--- a/dragonchain/lib/database/redis.py
+++ b/dragonchain/lib/database/redis.py
@@ -284,7 +284,7 @@ def hset_sync(name: str, key: str, value: str) -> int:
 
 
 def brpop_sync(keys: str, timeout: int = 0, decode: bool = True) -> Optional[tuple]:
-    """Preform a blocking pop against redis list(s)
+    """Perform a blocking pop against redis list(s)
     Args:
         keys: Can be a single key (bytes, string, int, etc), or an array of keys to wait on
         timeout: Number of seconds to wait before 'timing out' and returning None. If 0, it will block indefinitely (default)
@@ -294,6 +294,23 @@ def brpop_sync(keys: str, timeout: int = 0, decode: bool = True) -> Optional[tup
     """
     _set_redis_client_if_necessary()
     response = redis_client.brpop(keys, timeout=timeout)
+    if not response:
+        return None
+    return _decode_tuple_response(response, decode)
+
+
+def brpoplpush_sync(pop_key: str, push_key: str, timeout: int = 0, decode: bool = True) -> Optional[tuple]:
+    """Perform a blocking pop against redis list(s)
+    Args:
+        pop_key: Can be a single key (bytes, string, int, etc), or an array of keys to wait on popping from
+        push_key: key to push currently processing items to
+        timeout: Number of seconds to wait before 'timing out' and returning None. If 0, it will block indefinitely (default)
+    Returns:
+        None when no element could be popped and the timeout expired. This is only possible when timeout is not 0
+        A tuple with the first element being the key where the element was popped, and the second element being the value of the popped element.
+    """
+    _set_redis_client_if_necessary()
+    response = redis_client.brpoplpush(pop_key, push_key, timeout)
     if not response:
         return None
     return _decode_tuple_response(response, decode)

--- a/dragonchain/lib/database/redis_utest.py
+++ b/dragonchain/lib/database/redis_utest.py
@@ -145,6 +145,10 @@ class TestRedisAccess(unittest.IsolatedAsyncioTestCase):
         redis.brpop_sync("banana")
         redis.redis_client.brpop.assert_called_once_with("banana", timeout=0)
 
+    def test_brpoplpush(self):
+        redis.brpoplpush_sync("banana", "apple")
+        redis.redis_client.brpoplpush.assert_called_once_with("banana", "apple", 0)
+
     def test_get_sync(self):
         redis.get_sync("banana")
         redis.redis_client.get.assert_called_once_with("banana")

--- a/tools.sh
+++ b/tools.sh
@@ -85,7 +85,7 @@ elif [ "$1" = "docker-test" ]; then
     elif [ "$(uname -m)" = "aarch64" ]; then
         docker build . -f ./cicd/Dockerfile.test.arm64 -t dragonchain_testing_container --pull
     fi
-    docker run -v "$(pwd)":/usr/src/core dragonchain_testing_container
+    docker run -it -v "$(pwd)":/usr/src/core dragonchain_testing_container
 elif [ "$1" = "full-test" ]; then
     set +e
     printf "\\nChecking for linting errors\\n\\n"


### PR DESCRIPTION
## Description

Completes an old JIRA item to add recovery flow to job processor in case of unexpected crashes.

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] tests are included
- [x] changelog has been modified for the changes
