### PR TITLE
Restrict smart contract secret name charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Bugs:**
   - Fix bug where updating an existing secret for a smart contract would cause the contract deployment to fail
   - Restrict contract create/update schema to deny overwriting reserved 'secret-key' and 'auth-key-id' secrets
+  - Restrict contract create/update schema to only allow a restricted character-set for secret names so invalid names can't be used (which would previously cause the smart contract build to fail)
 - **Documentation:**
   - Edit notes about ram usage requirements for Dragonchain
   - Add documentation for deploying with a raspberry pi

--- a/dragonchain/lib/dto/schema.py
+++ b/dragonchain/lib/dto/schema.py
@@ -534,7 +534,7 @@ smart_contract_create_schema_v1 = {
         "secrets": {
             "type": "object",
             # Don't allow secrets to overwrite 'secret-key' or 'auth-key-id'
-            "patternProperties": {"^(?=(?!secret-key))(?=(?!auth-key-id)).+$": {"type": "string"}},
+            "patternProperties": {"^(?=(?!secret-key))(?=(?!auth-key-id))[a-z0-9-]+$": {"type": "string"}},
             "additionalProperties": False,
         },
         "seconds": {"type": "integer", "minimum": 1, "maximum": 60},
@@ -562,7 +562,7 @@ smart_contract_update_schema_v1 = {
         "secrets": {
             "type": "object",
             # Don't allow secrets to overwrite 'secret-key' or 'auth-key-id'
-            "patternProperties": {"^(?=(?!secret-key))(?=(?!auth-key-id)).+$": {"type": "string"}},
+            "patternProperties": {"^(?=(?!secret-key))(?=(?!auth-key-id))[a-z0-9-]+$": {"type": "string"}},
             "additionalProperties": False,
         },
         "seconds": {"type": "integer", "minimum": 1, "maximum": 60},


### PR DESCRIPTION
## Description

Some characters would not work as openfaas secret names, and others (such as uppercase letters) get converted.

This PR simply restricts the charset of smart contract secret names to be a simple set that should never cause a smart contract build to fail, or get unexpectedly converted

This charset is: a-z, 0-9, and the literal character `-`

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] changelog has been modified for the changes
