### PR TITLE
fix tests (python 3.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## 4.3.3
 
 - **Packaging:**
-  - Update boto3 dependencies
+  - Update redisearch, and boto3 dependencies
+  - Un-pin python to version 3.8.X
+- **Development:**
+  - Fix tests for python 3.8.1
 
 ## 4.3.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.0-alpine as base
+FROM python:3.8-alpine as base
 
 WORKDIR /usr/src/core
 # Install necessary base dependencies and set UTC timezone for apscheduler

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/python:3.8.0-alpine as base
+FROM arm64v8/python:3.8-alpine as base
 
 WORKDIR /usr/src/core
 # Install necessary base dependencies and set UTC timezone for apscheduler

--- a/cicd/Dockerfile.dependencies
+++ b/cicd/Dockerfile.dependencies
@@ -1,5 +1,5 @@
 # This container is used as a base by Dockerfile.test in order to speed up dependency install for testing purposes only
-FROM amd64/python:3.8.0-alpine
+FROM amd64/python:3.8-alpine
 
 WORKDIR /usr/src/core
 # Install necessary base dependencies and set UTC timezone for apscheduler

--- a/cicd/Dockerfile.dependencies.arm64
+++ b/cicd/Dockerfile.dependencies.arm64
@@ -1,5 +1,5 @@
 # This container is used as a base by Dockerfile.test.arm64 in order to speed up dependency install for testing purposes only
-FROM arm64v8/python:3.8.0-alpine
+FROM arm64v8/python:3.8-alpine
 
 WORKDIR /usr/src/core
 # Install necessary base dependencies and set UTC timezone for apscheduler

--- a/dragonchain/broadcast_processor/broadcast_functions_utest.py
+++ b/dragonchain/broadcast_processor/broadcast_functions_utest.py
@@ -15,29 +15,15 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 
-import asyncio
-import importlib
 import unittest
-from unittest.mock import patch, MagicMock, call, ANY
+from unittest.mock import patch, MagicMock, AsyncMock, call, ANY
 
 from dragonchain import test_env  # noqa: F401
 from dragonchain.broadcast_processor import broadcast_functions
 from dragonchain import exceptions
 
 
-def async_test(coro):
-    def wrapper(*args, **kwargs):
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(coro(*args, **kwargs))
-
-    return wrapper
-
-
-class BroadcastFunctionTests(unittest.TestCase):
-    def tearDown(self):
-        # Necessary because we modify the class during testing...
-        importlib.reload(broadcast_functions.redis)
-
+class BroadcastFunctionTests(unittest.IsolatedAsyncioTestCase):
     def test_state_key_returns_correct_key(self):
         self.assertEqual(broadcast_functions.state_key("id"), "broadcast:block:id:state")
 
@@ -61,6 +47,7 @@ class BroadcastFunctionTests(unittest.TestCase):
         get_sync.assert_called_once_with("key", decode=False)
         set_sync.assert_called_once_with("key", "3")
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.pipeline_sync")
     @patch("dragonchain.broadcast_processor.broadcast_functions.storage_error_key", return_value="error_key")
     @patch("dragonchain.broadcast_processor.broadcast_functions.verifications_key", return_value="verifications_key")
     @patch("dragonchain.broadcast_processor.broadcast_functions.state_key", return_value="state_key")
@@ -68,39 +55,35 @@ class BroadcastFunctionTests(unittest.TestCase):
     @patch("dragonchain.broadcast_processor.broadcast_functions.redis.smembers_sync", return_value={"abc", "def"})
     @patch("dragonchain.broadcast_processor.broadcast_functions.storage.list_objects", return_value=["BLOCK/blah-l2-abc"])
     def test_storage_error_rolls_back_state_correctly_when_needed(
-        self, list_objects, smembers_sync, get_sync, state_key, verifications_key, error_key
+        self, list_objects, smembers_sync, get_sync, state_key, verifications_key, error_key, mock_pipeline
     ):
         fake_pipeline = MagicMock()
-        broadcast_functions.redis.pipeline_sync = MagicMock(return_value=fake_pipeline)
+        mock_pipeline.return_value = fake_pipeline
         broadcast_functions.increment_storage_error_sync("blah", 3)
-        broadcast_functions.redis.pipeline_sync.assert_called_once()
+        mock_pipeline.assert_called_once()
         fake_pipeline.srem.assert_called_once_with("verifications_key", "def")
         fake_pipeline.delete.assert_called_once_with("error_key")
         fake_pipeline.set.assert_called_once_with("state_key", "2")
         fake_pipeline.execute.assert_called_once()
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.z_range_by_score_async", return_value="dummy")
     @patch("dragonchain.broadcast_processor.broadcast_functions.time.time", return_value=123)
-    @async_test
-    async def test_get_for_process_async(self, mock_time):
-        broadcast_functions.redis.z_range_by_score_async = MagicMock(return_value=asyncio.Future())
-        broadcast_functions.redis.z_range_by_score_async.return_value.set_result("dummy")
+    async def test_get_for_process_async(self, mock_time, mock_zrange):
         self.assertEqual(await broadcast_functions.get_blocks_to_process_for_broadcast_async(), "dummy")
         mock_time.assert_called_once()
-        broadcast_functions.redis.z_range_by_score_async.assert_called_once_with("broadcast:in-flight", 0, 123, withscores=True, offset=0, count=1000)
+        mock_zrange.assert_awaited_once_with("broadcast:in-flight", 0, 123, withscores=True, offset=0, count=1000)
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.get_async", return_value="3")
     @patch("dragonchain.broadcast_processor.broadcast_functions.state_key", return_value="key")
-    @async_test
-    async def test_get_block_level_async(self, mock_key):
-        broadcast_functions.redis.get_async = MagicMock(return_value=asyncio.Future())
-        broadcast_functions.redis.get_async.return_value.set_result("3")
+    async def test_get_block_level_async(self, mock_key, mock_get):
         self.assertEqual(await broadcast_functions.get_current_block_level_async("blah"), 3)
-        broadcast_functions.redis.get_async.assert_called_once_with("key", decode=False)
+        mock_get.assert_awaited_once_with("key", decode=False)
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.get_sync", return_value=b"3")
     @patch("dragonchain.broadcast_processor.broadcast_functions.state_key", return_value="key")
-    def test_get_block_level_sync(self, mock_key):
-        broadcast_functions.redis.get_sync = MagicMock(return_value=b"3")
+    def test_get_block_level_sync(self, mock_key, mock_get):
         self.assertEqual(broadcast_functions.get_current_block_level_sync("blah"), 3)
-        broadcast_functions.redis.get_sync.assert_called_once_with("key", decode=False)
+        mock_get.assert_called_once_with("key", decode=False)
 
     @patch("dragonchain.broadcast_processor.broadcast_functions.get_current_block_level_sync", return_value=3)
     def test_block_accepting_from_level(self, mock_get_block_level):
@@ -108,42 +91,39 @@ class BroadcastFunctionTests(unittest.TestCase):
         mock_get_block_level.assert_called_once_with("blah")
         self.assertFalse(broadcast_functions.is_block_accepting_verifications_from_level("blah", 4))
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.set_async")
     @patch("dragonchain.broadcast_processor.broadcast_functions.state_key", return_value="key")
-    @async_test
-    async def test_set_block_level_async_calls_redis_with_correct_params(self, mock_key):
-        broadcast_functions.redis.set_async = MagicMock(return_value=asyncio.Future())
-        broadcast_functions.redis.set_async.return_value.set_result("doesnt matter")
+    async def test_set_block_level_async_calls_redis_with_correct_params(self, mock_key, mock_set):
         await broadcast_functions.set_current_block_level_async("blah", 3)
-        broadcast_functions.redis.set_async.assert_called_once_with("key", "3")
+        mock_set.assert_awaited_once_with("key", "3")
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.set_sync")
     @patch("dragonchain.broadcast_processor.broadcast_functions.state_key", return_value="key")
-    def test_set_block_level_sync_calls_redis_with_correct_params(self, mock_key):
-        broadcast_functions.redis.set_sync = MagicMock(return_value="doesnt matter")
+    def test_set_block_level_sync_calls_redis_with_correct_params(self, mock_key, mock_set):
         broadcast_functions.set_current_block_level_sync("blah", 3)
-        broadcast_functions.redis.set_sync.assert_called_once_with("key", "3")
+        mock_set.assert_called_once_with("key", "3")
 
-    @async_test
-    async def test_schedule_block_async_calls_redis_with_correct_params(self):
-        broadcast_functions.redis.zadd_async = MagicMock(return_value=asyncio.Future())
-        broadcast_functions.redis.zadd_async.return_value.set_result("doesnt matter")
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.zadd_async")
+    async def test_schedule_block_async_calls_redis_with_correct_params(self, mock_zadd):
         await broadcast_functions.schedule_block_for_broadcast_async("id", 123)
-        broadcast_functions.redis.zadd_async.assert_called_once_with("broadcast:in-flight", 123, "id")
+        mock_zadd.assert_awaited_once_with("broadcast:in-flight", 123, "id")
 
-    def test_schedule_block_sync_calls_redis_with_correct_params(self):
-        broadcast_functions.redis.zadd_sync = MagicMock(return_value="doesnt matter")
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.zadd_sync")
+    def test_schedule_block_sync_calls_redis_with_correct_params(self, mock_zadd):
         broadcast_functions.schedule_block_for_broadcast_sync("id", 123)
-        broadcast_functions.redis.zadd_sync.assert_called_once_with("broadcast:in-flight", {"id": 123})
+        mock_zadd.assert_called_once_with("broadcast:in-flight", {"id": 123})
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.pipeline_sync")
     @patch("dragonchain.broadcast_processor.broadcast_functions.verifications_key", return_value="verification_key")
-    def test_get_all_verifications_sync(self, mock_verification_key):
+    def test_get_all_verifications_sync(self, mock_verification_key, mock_pipeline):
         fake_pipeline = MagicMock()
         fake_pipeline.execute.return_value = [{b"l2chain1", b"l2chain2"}, {b"l3chain"}, {b"l4chain"}, set()]
-        broadcast_functions.redis.pipeline_sync = MagicMock(return_value=fake_pipeline)
+        mock_pipeline.return_value = fake_pipeline
 
         result = broadcast_functions.get_all_verifications_for_block_sync("id")
 
         # Check that mocks were called as expected
-        broadcast_functions.redis.pipeline_sync.assert_called_once()
+        mock_pipeline.assert_called_once()
         smembers_calls = [call("verification_key"), call("verification_key"), call("verification_key"), call("verification_key")]
         fake_pipeline.smembers.assert_has_calls(smembers_calls)
         fake_pipeline.execute.assert_called_once()
@@ -153,28 +133,27 @@ class BroadcastFunctionTests(unittest.TestCase):
         # Check actual result
         self.assertEqual(result, [{"l2chain1", "l2chain2"}, {"l3chain"}, {"l4chain"}, set()])
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.smembers_sync", return_value={b"thing"})
     @patch("dragonchain.broadcast_processor.broadcast_functions.verifications_key", return_value="key")
-    def test_get_verifications_sync(self, mock_key):
-        broadcast_functions.redis.smembers_sync = MagicMock(return_value={b"thing"})
+    def test_get_verifications_sync(self, mock_key, mock_smembers):
         self.assertEqual(broadcast_functions.get_receieved_verifications_for_block_and_level_sync("id", 2), {b"thing"})
-        broadcast_functions.redis.smembers_sync.assert_called_once_with("key")
+        mock_smembers.assert_called_once_with("key")
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.smembers_async", return_value={"thing"})
     @patch("dragonchain.broadcast_processor.broadcast_functions.verifications_key", return_value="key")
-    @async_test
-    async def test_get_verifications_async(self, mock_key):
-        broadcast_functions.redis.smembers_async = MagicMock(return_value=asyncio.Future())
-        broadcast_functions.redis.smembers_async.return_value.set_result({"thing"})
+    async def test_get_verifications_async(self, mock_key, mock_smembers):
         self.assertEqual(await broadcast_functions.get_receieved_verifications_for_block_and_level_async("id", 2), {"thing"})
-        broadcast_functions.redis.smembers_async.assert_called_once_with("key")
+        mock_smembers.assert_awaited_once_with("key")
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.pipeline_sync")
     @patch("dragonchain.broadcast_processor.broadcast_functions.state_key", return_value="state_key")
     @patch("dragonchain.broadcast_processor.broadcast_functions.verifications_key", return_value="verification_key")
     @patch("dragonchain.broadcast_processor.broadcast_functions.storage_error_key", return_value="storage_error_key")
-    def test_remove_block_sync_calls_redis_with_correct_deletes(self, mock_error_key, mock_verification_key, mock_state_key):
+    def test_remove_block_sync_calls_redis_with_correct_deletes(self, mock_error_key, mock_verification_key, mock_state_key, mock_pipeline):
         fake_pipeline = MagicMock()
-        broadcast_functions.redis.pipeline_sync = MagicMock(return_value=fake_pipeline)
+        mock_pipeline.return_value = fake_pipeline
         broadcast_functions.remove_block_from_broadcast_system_sync("id")
-        broadcast_functions.redis.pipeline_sync.assert_called_once()
+        mock_pipeline.assert_called_once()
         fake_pipeline.zrem.assert_called_once_with("broadcast:in-flight", "id")
         fake_pipeline.hdel.assert_called_once_with("broadcast:claimcheck", "id")
         delete_calls = [
@@ -191,18 +170,15 @@ class BroadcastFunctionTests(unittest.TestCase):
         verification_key_calls = [call("id", 2), call("id", 3), call("id", 4), call("id", 5)]
         mock_verification_key.assert_has_calls(verification_key_calls)
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.multi_exec_async")
     @patch("dragonchain.broadcast_processor.broadcast_functions.state_key", return_value="state_key")
     @patch("dragonchain.broadcast_processor.broadcast_functions.verifications_key", return_value="verification_key")
     @patch("dragonchain.broadcast_processor.broadcast_functions.storage_error_key", return_value="storage_error_key")
-    @async_test
-    async def test_remove_block_async_calls_redis_with_correct_deletes(self, mock_error_key, mock_verification_key, mock_state_key):
-        fake_pipeline = MagicMock()
-        fake_pipeline.execute = MagicMock(return_value=asyncio.Future())
-        fake_pipeline.execute.return_value.set_result(None)
-        broadcast_functions.redis.multi_exec_async = MagicMock(return_value=asyncio.Future())
-        broadcast_functions.redis.multi_exec_async.return_value.set_result(fake_pipeline)
+    async def test_remove_block_async_calls_redis_with_correct_deletes(self, mock_error_key, mock_verification_key, mock_state_key, mock_multi_exec):
+        fake_pipeline = MagicMock(execute=AsyncMock())
+        mock_multi_exec.return_value = fake_pipeline
         await broadcast_functions.remove_block_from_broadcast_system_async("id")
-        broadcast_functions.redis.multi_exec_async.assert_called_once()
+        mock_multi_exec.assert_awaited_once()
         fake_pipeline.zrem.assert_called_once_with("broadcast:in-flight", "id")
         fake_pipeline.hdel.assert_called_once_with("broadcast:claimcheck", "id")
         delete_calls = [
@@ -214,7 +190,7 @@ class BroadcastFunctionTests(unittest.TestCase):
             call("verification_key"),
         ]
         fake_pipeline.delete.assert_has_calls(delete_calls)
-        fake_pipeline.execute.assert_called_once()
+        fake_pipeline.execute.assert_awaited_once()
         mock_state_key.assert_called_once_with("id")
         verification_key_calls = [call("id", 2), call("id", 3), call("id", 4), call("id", 5)]
         mock_verification_key.assert_has_calls(verification_key_calls)
@@ -226,20 +202,22 @@ class BroadcastFunctionTests(unittest.TestCase):
             exceptions.NotAcceptingVerifications, broadcast_functions.set_receieved_verification_for_block_from_chain_sync, "block_id", 2, "chain_id"
         )
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.pipeline_sync")
     @patch("dragonchain.broadcast_processor.broadcast_functions.redis.sadd_sync")
     @patch("dragonchain.broadcast_processor.broadcast_functions.dragonnet_config.DRAGONNET_CONFIG", {"l2": {"nodesRequired": 3}})
     @patch("dragonchain.broadcast_processor.broadcast_functions.verifications_key", return_value="key")
     @patch("dragonchain.broadcast_processor.broadcast_functions.get_current_block_level_sync", return_value=2)
-    def test_set_record_for_block_sync_calls_redis_with_correct_params(self, mock_get_block_level, mock_key, mock_sadd):
+    def test_set_record_for_block_sync_calls_redis_with_correct_params(self, mock_get_block_level, mock_key, mock_sadd, mock_pipeline):
         fake_pipeline = MagicMock()
-        fake_pipeline.execute = MagicMock(return_value=[1, 2])
-        broadcast_functions.redis.pipeline_sync = MagicMock(return_value=fake_pipeline)
+        fake_pipeline.execute.return_value = [1, 2]
+        mock_pipeline.return_value = fake_pipeline
         broadcast_functions.set_receieved_verification_for_block_from_chain_sync("block_id", 2, "chain_id")
-        broadcast_functions.redis.pipeline_sync.assert_called_once()
+        mock_pipeline.assert_called_once()
         fake_pipeline.sadd.assert_called_once_with("key", "chain_id")
         fake_pipeline.scard.assert_called_once_with("key")
         fake_pipeline.execute.assert_called_once()
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.pipeline_sync")
     @patch("dragonchain.broadcast_processor.broadcast_functions.redis.sadd_sync")
     @patch("dragonchain.broadcast_processor.broadcast_functions.dragonnet_config.DRAGONNET_CONFIG", {"l3": {"nodesRequired": 3}})
     @patch("dragonchain.broadcast_processor.broadcast_functions.set_current_block_level_sync")
@@ -248,62 +226,57 @@ class BroadcastFunctionTests(unittest.TestCase):
     @patch("dragonchain.broadcast_processor.broadcast_functions.get_current_block_level_sync", return_value=3)
     @patch("dragonchain.broadcast_processor.broadcast_functions.redis.delete_sync")
     def test_set_record_for_block_sync_promotes_when_needed_met(
-        self, mock_delete_sync, mock_get_block_level, mock_key, mock_schedule, mock_set_block, mock_sadd
+        self, mock_delete_sync, mock_get_block_level, mock_key, mock_schedule, mock_set_block, mock_sadd, mock_pipeline
     ):
         fake_pipeline = MagicMock()
-        fake_pipeline.execute = MagicMock(return_value=[1, 3])
-        broadcast_functions.redis.pipeline_sync = MagicMock(return_value=fake_pipeline)
+        fake_pipeline.execute.return_value = [1, 3]
+        mock_pipeline.return_value = fake_pipeline
         broadcast_functions.set_receieved_verification_for_block_from_chain_sync("block_id", 3, "chain_id")
         mock_set_block.assert_called_once_with("block_id", 4)
         mock_schedule.assert_called_once_with("block_id")
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.pipeline_sync")
     @patch("dragonchain.broadcast_processor.broadcast_functions.redis.sadd_sync")
     @patch("dragonchain.broadcast_processor.broadcast_functions.dragonnet_config.DRAGONNET_CONFIG", {"l5": {"nodesRequired": 3}})
     @patch("dragonchain.broadcast_processor.broadcast_functions.remove_block_from_broadcast_system_sync")
     @patch("dragonchain.broadcast_processor.broadcast_functions.verifications_key", return_value="key")
     @patch("dragonchain.broadcast_processor.broadcast_functions.get_current_block_level_sync", return_value=5)
-    def test_set_record_for_block_sync_calls_remove_when_required_met_and_level_5(self, mock_get_block_level, mock_key, mock_remove, mock_sadd):
+    def test_set_record_for_block_sync_calls_remove_when_required_met_and_level_5(
+        self, mock_get_block_level, mock_key, mock_remove, mock_sadd, mock_pipeline
+    ):
         fake_pipeline = MagicMock()
-        fake_pipeline.execute = MagicMock(return_value=[1, 3])
-        broadcast_functions.redis.pipeline_sync = MagicMock(return_value=fake_pipeline)
+        fake_pipeline.execute.return_value = [1, 3]
+        mock_pipeline.return_value = fake_pipeline
         broadcast_functions.set_receieved_verification_for_block_from_chain_sync("block_id", 5, "chain_id")
         mock_remove.assert_called_once_with("block_id")
 
-    @async_test
-    async def test_get_notification_verifications_for_broadcast_async(self):
-        broadcast_functions.redis.smembers_async = MagicMock(return_value=asyncio.Future())
-        broadcast_functions.redis.smembers_async.return_value.set_result({"thing"})
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.smembers_async", return_value={"thing"})
+    async def test_get_notification_verifications_for_broadcast_async(self, mock_smembers):
         await broadcast_functions.get_notification_verifications_for_broadcast_async()
-        broadcast_functions.redis.smembers_async.assert_called_once_with("broadcast:notifications")
+        mock_smembers.assert_awaited_once_with("broadcast:notifications")
 
-    @async_test
-    async def test_remove_notification_verification_for_broadcast_async(self):
-        broadcast_functions.redis.srem_async = MagicMock(return_value=asyncio.Future())
-        broadcast_functions.redis.srem_async.return_value.set_result(1)
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.srem_async", return_value=1)
+    async def test_remove_notification_verification_for_broadcast_async(self, mock_srem):
         await broadcast_functions.remove_notification_verification_for_broadcast_async("banana")
-        broadcast_functions.redis.srem_async.assert_called_once_with("broadcast:notifications", "banana")
+        mock_srem.assert_awaited_once_with("broadcast:notifications", "banana")
 
-    def test_schedule_notification_for_broadcast_sync(self):
-        broadcast_functions.redis.sadd_sync = MagicMock(return_value=1)
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.sadd_sync", return_value=1)
+    def test_schedule_notification_for_broadcast_sync(self, mock_sadd):
         broadcast_functions.schedule_notification_for_broadcast_sync("banana")
-        broadcast_functions.redis.sadd_sync.assert_called_once_with("broadcast:notifications", "banana")
+        mock_sadd.assert_called_once_with("broadcast:notifications", "banana")
 
     def test_verification_storage_location(self):
         result = broadcast_functions.verification_storage_location("l1_block_id", 2, "chain_id")
         self.assertEqual(result, "BLOCK/l1_block_id-l2-chain_id")
 
-    @patch("dragonchain.broadcast_processor.broadcast_functions.storage")
-    @async_test
-    async def test_save_unfinished_claim_writes_to_storage(self, mock_storage):
-        broadcast_functions.remove_block_from_broadcast_system_async = MagicMock(return_value=asyncio.Future())
-        broadcast_functions.remove_block_from_broadcast_system_async.return_value.set_result(None)
+    @patch("dragonchain.broadcast_processor.broadcast_functions.remove_block_from_broadcast_system_async")
+    @patch("dragonchain.broadcast_processor.broadcast_functions.storage.put_object_as_json")
+    async def test_save_unfinished_claim_writes_to_storage(self, mock_put, mock_remove):
         await broadcast_functions.save_unfinished_claim("123")
-        mock_storage.put_object_as_json.assert_called_once_with("BROADCASTS/UNFINISHED/123", ANY)
+        mock_put.assert_called_once_with("BROADCASTS/UNFINISHED/123", ANY)
 
+    @patch("dragonchain.broadcast_processor.broadcast_functions.remove_block_from_broadcast_system_async")
     @patch("dragonchain.broadcast_processor.broadcast_functions.storage")
-    @async_test
-    async def test_save_unfinished_claim_removes_claim_from_system(self, mock_storage):
-        broadcast_functions.remove_block_from_broadcast_system_async = MagicMock(return_value=asyncio.Future())
-        broadcast_functions.remove_block_from_broadcast_system_async.return_value.set_result(None)
+    async def test_save_unfinished_claim_removes_claim_from_system(self, mock_storage, mock_remove):
         await broadcast_functions.save_unfinished_claim("123")
-        broadcast_functions.remove_block_from_broadcast_system_async.assert_called_once_with("123")
+        mock_remove.assert_awaited_once_with("123")

--- a/dragonchain/broadcast_processor/broadcast_processor_utest.py
+++ b/dragonchain/broadcast_processor/broadcast_processor_utest.py
@@ -178,7 +178,7 @@ class BroadcastProcessorTests(unittest.IsolatedAsyncioTestCase):
     async def test_process_blocks_gets_blocks_for_broadcast(self, mock_get_blocks, mock_gather):
         mock_gather.return_value.set_result(None)
         await broadcast_processor.process_blocks_for_broadcast(None)
-        mock_get_blocks.assert_called_once()
+        mock_get_blocks.assert_awaited_once()
 
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.matchmaking.get_or_create_claim_check",
@@ -212,7 +212,7 @@ class BroadcastProcessorTests(unittest.IsolatedAsyncioTestCase):
     async def test_process_blocks_sleeps_with_insufficient_funds(self, mock_get_blocks, mock_gather, mock_get_block_level, mock_sleep, mock_claim):
         mock_gather.return_value.set_result(None)
         await broadcast_processor.process_blocks_for_broadcast(None)
-        mock_sleep.assert_called_once_with(1800)
+        mock_sleep.assert_awaited_once_with(1800)
 
     @patch("dragonchain.broadcast_processor.broadcast_processor.matchmaking.get_or_create_claim_check")
     @patch("dragonchain.broadcast_processor.broadcast_processor.time.time", return_value=123)
@@ -244,7 +244,7 @@ class BroadcastProcessorTests(unittest.IsolatedAsyncioTestCase):
         mock_gather.return_value.set_result(None)
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_get_futures.assert_called_once_with(None, "block_id", 2, {"chain_id"})
-        mock_schedule_broadcast.assert_called_once_with("block_id", 123 + broadcast_processor.BROADCAST_RECEIPT_WAIT_TIME)
+        mock_schedule_broadcast.assert_awaited_once_with("block_id", 123 + broadcast_processor.BROADCAST_RECEIPT_WAIT_TIME)
         mock_gather.assert_called_once_with(return_exceptions=True)
         mock_get_verifications.assert_not_called()
 
@@ -297,8 +297,8 @@ class BroadcastProcessorTests(unittest.IsolatedAsyncioTestCase):
     ):
         mock_gather.return_value.set_result(None)
         await broadcast_processor.process_blocks_for_broadcast(None)
-        mock_set_block_level.assert_called_once_with("block_id", 3)
-        mock_schedule_broadcast.assert_called_once_with("block_id")
+        mock_set_block_level.assert_awaited_once_with("block_id", 3)
+        mock_schedule_broadcast.assert_awaited_once_with("block_id")
 
     @patch("dragonchain.broadcast_processor.broadcast_processor.matchmaking.get_or_create_claim_check")
     @patch(
@@ -405,7 +405,7 @@ class BroadcastProcessorTests(unittest.IsolatedAsyncioTestCase):
         mock_gather.return_value.set_result(None)
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_get_futures.assert_called_once_with(None, "block_id", 2, {"chain_id"})
-        mock_schedule_broadcast.assert_called_once_with("block_id", 123 + broadcast_processor.BROADCAST_RECEIPT_WAIT_TIME)
+        mock_schedule_broadcast.assert_awaited_once_with("block_id", 123 + broadcast_processor.BROADCAST_RECEIPT_WAIT_TIME)
         mock_gather.assert_called_once_with(return_exceptions=True)
 
     @patch("dragonchain.broadcast_processor.broadcast_processor.matchmaking.get_or_create_claim_check")
@@ -456,10 +456,10 @@ class BroadcastProcessorTests(unittest.IsolatedAsyncioTestCase):
         broadcast_processor.VERIFICATION_NOTIFICATION = {"all": ["url1"]}
         fake_session = AsyncMock(post=AsyncMock())
         await broadcast_processor.process_verification_notifications(fake_session)
-        fake_session.post.assert_called_once_with(
+        fake_session.post.assert_awaited_once_with(
             data=b"location-object-bytes", headers={"dragonchainId": "my-public-id", "signature": "my-signature"}, timeout=30, url="url1"
         )
-        srem_mock.assert_called_once_with("broadcast:notifications", "BLOCK/banana-l2-whatever")
+        srem_mock.assert_awaited_once_with("broadcast:notifications", "BLOCK/banana-l2-whatever")
 
     @patch(
         "dragonchain.broadcast_processor.broadcast_functions.get_notification_verifications_for_broadcast_async",
@@ -478,4 +478,4 @@ class BroadcastProcessorTests(unittest.IsolatedAsyncioTestCase):
         fake_session.post.assert_called_once_with(
             data=b"location-object-bytes", headers={"dragonchainId": "my-public-id", "signature": "my-signature"}, timeout=30, url="url1"
         )
-        srem_mock.assert_called_once_with("broadcast:notifications", "BLOCK/banana-l2-whatever")
+        srem_mock.assert_awaited_once_with("broadcast:notifications", "BLOCK/banana-l2-whatever")

--- a/dragonchain/broadcast_processor/broadcast_processor_utest.py
+++ b/dragonchain/broadcast_processor/broadcast_processor_utest.py
@@ -18,22 +18,14 @@
 import importlib
 import asyncio
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from dragonchain import test_env  # noqa: F401
 from dragonchain.broadcast_processor import broadcast_processor
 from dragonchain import exceptions
 
 
-def async_test(coro):
-    def wrapper(*args, **kwargs):
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(coro(*args, **kwargs))
-
-    return wrapper
-
-
-class BroadcastProcessorTests(unittest.TestCase):
+class BroadcastProcessorTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         importlib.reload(broadcast_processor)
         broadcast_processor.BROADCAST = "true"
@@ -181,13 +173,10 @@ class BroadcastProcessorTests(unittest.TestCase):
 
     @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.gather", return_value=asyncio.Future())
     @patch(
-        "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_blocks_to_process_for_broadcast_async",
-        return_value=asyncio.Future(),
+        "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_blocks_to_process_for_broadcast_async", return_value=[],
     )
-    @async_test
     async def test_process_blocks_gets_blocks_for_broadcast(self, mock_get_blocks, mock_gather):
         mock_gather.return_value.set_result(None)
-        mock_get_blocks.return_value.set_result([])
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_get_blocks.assert_called_once()
 
@@ -195,43 +184,33 @@ class BroadcastProcessorTests(unittest.TestCase):
         "dragonchain.broadcast_processor.broadcast_processor.matchmaking.get_or_create_claim_check",
         return_value={"metadata": {"dcId": "banana-dc-id"}},
     )
-    @patch(
-        "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async", return_value=asyncio.Future()
-    )
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async")
     @patch("dragonchain.broadcast_processor.broadcast_processor.make_broadcast_futures")
     @patch("dragonchain.broadcast_processor.broadcast_processor.chain_id_set_from_matchmaking_claim")
-    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=asyncio.Future())
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=2)
     @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.gather", return_value=asyncio.Future())
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_blocks_to_process_for_broadcast_async",
-        return_value=asyncio.Future(),
+        return_value=[("block_id", 0)],
     )
-    @async_test
     async def test_process_blocks_calls_matchmaking_for_claims(
         self, mock_get_blocks, mock_gather, mock_get_block_level, mock_chain_id_set, mock_get_futures, mock_schedule_broadcast, mock_claim
     ):
-        mock_schedule_broadcast.return_value.set_result(None)
-        mock_get_block_level.return_value.set_result(2)
         mock_gather.return_value.set_result(None)
-        mock_get_blocks.return_value.set_result([("block_id", 0)])
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_claim.assert_called_once_with("block_id", broadcast_processor._requirements)
         mock_chain_id_set.assert_called_once_with({"metadata": {"dcId": "banana-dc-id"}}, 2)
 
     @patch("dragonchain.broadcast_processor.broadcast_processor.matchmaking.get_or_create_claim_check", side_effect=exceptions.InsufficientFunds)
-    @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.sleep", return_value=asyncio.Future())
-    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=asyncio.Future())
+    @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.sleep")
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=None)
     @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.gather", return_value=asyncio.Future())
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_blocks_to_process_for_broadcast_async",
-        return_value=asyncio.Future(),
+        return_value=[("block_id", 0)],
     )
-    @async_test
     async def test_process_blocks_sleeps_with_insufficient_funds(self, mock_get_blocks, mock_gather, mock_get_block_level, mock_sleep, mock_claim):
-        mock_sleep.return_value.set_result(None)
-        mock_get_block_level.return_value.set_result(None)
         mock_gather.return_value.set_result(None)
-        mock_get_blocks.return_value.set_result([("block_id", 0)])
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_sleep.assert_called_once_with(1800)
 
@@ -239,20 +218,17 @@ class BroadcastProcessorTests(unittest.TestCase):
     @patch("dragonchain.broadcast_processor.broadcast_processor.time.time", return_value=123)
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_receieved_verifications_for_block_and_level_async",
-        return_value=asyncio.Future(),
+        return_value=None,
     )
-    @patch(
-        "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async", return_value=asyncio.Future()
-    )
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async")
     @patch("dragonchain.broadcast_processor.broadcast_processor.make_broadcast_futures")
     @patch("dragonchain.broadcast_processor.broadcast_processor.chain_id_set_from_matchmaking_claim", return_value={"chain_id"})
-    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=asyncio.Future())
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=2)
     @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.gather", return_value=asyncio.Future())
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_blocks_to_process_for_broadcast_async",
-        return_value=asyncio.Future(),
+        return_value=[("block_id", 0)],
     )
-    @async_test
     async def test_process_blocks_fires_requests_and_reschedules_for_new_block(
         self,
         mock_get_blocks,
@@ -265,11 +241,7 @@ class BroadcastProcessorTests(unittest.TestCase):
         mock_time,
         mock_claim,
     ):
-        mock_get_verifications.return_value.set_result(None)
-        mock_schedule_broadcast.return_value.set_result(None)
-        mock_get_block_level.return_value.set_result(2)
         mock_gather.return_value.set_result(None)
-        mock_get_blocks.return_value.set_result([("block_id", 0)])
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_get_futures.assert_called_once_with(None, "block_id", 2, {"chain_id"})
         mock_schedule_broadcast.assert_called_once_with("block_id", 123 + broadcast_processor.BROADCAST_RECEIPT_WAIT_TIME)
@@ -277,48 +249,39 @@ class BroadcastProcessorTests(unittest.TestCase):
         mock_get_verifications.assert_not_called()
 
     @patch("dragonchain.broadcast_processor.broadcast_processor.matchmaking.get_or_create_claim_check")
-    @patch(
-        "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async", return_value=asyncio.Future()
-    )
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async")
     @patch("dragonchain.broadcast_processor.broadcast_processor.make_broadcast_futures", return_value=None)
     @patch("dragonchain.broadcast_processor.broadcast_processor.chain_id_set_from_matchmaking_claim", return_value={"chain_id"})
-    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=asyncio.Future())
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=2)
     @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.gather", return_value=asyncio.Future())
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_blocks_to_process_for_broadcast_async",
-        return_value=asyncio.Future(),
+        return_value=[("block_id", 0)],
     )
-    @async_test
     async def test_process_blocks_doesnt_reschedule_new_block_which_failed_had_no_futures(
         self, mock_get_blocks, mock_gather, mock_get_block_level, mock_chain_id_set, mock_get_futures, mock_schedule_broadcast, mock_claim
     ):
-        mock_schedule_broadcast.return_value.set_result(None)
-        mock_get_block_level.return_value.set_result(2)
         mock_gather.return_value.set_result(None)
-        mock_get_blocks.return_value.set_result([("block_id", 0)])
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_get_futures.assert_called_once()
         mock_schedule_broadcast.assert_not_called()
 
     @patch("dragonchain.broadcast_processor.broadcast_processor.matchmaking.get_or_create_claim_check")
-    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.set_current_block_level_async", return_value=asyncio.Future())
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.set_current_block_level_async")
     @patch("dragonchain.broadcast_processor.broadcast_processor.needed_verifications", return_value=0)
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_receieved_verifications_for_block_and_level_async",
-        return_value=asyncio.Future(),
+        return_value={"verification"},
     )
-    @patch(
-        "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async", return_value=asyncio.Future()
-    )
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async")
     @patch("dragonchain.broadcast_processor.broadcast_processor.make_broadcast_futures")
     @patch("dragonchain.broadcast_processor.broadcast_processor.chain_id_set_from_matchmaking_claim", return_value={"chain_id"})
-    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=asyncio.Future())
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=2)
     @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.gather", return_value=asyncio.Future())
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_blocks_to_process_for_broadcast_async",
-        return_value=asyncio.Future(),
+        return_value=[("block_id", 1)],
     )
-    @async_test
     async def test_process_blocks_promotes_block_with_enough_verifications(
         self,
         mock_get_blocks,
@@ -332,12 +295,7 @@ class BroadcastProcessorTests(unittest.TestCase):
         mock_set_block_level,
         mock_claim_check,
     ):
-        mock_set_block_level.return_value.set_result(None)
-        mock_get_verifications.return_value.set_result({"verification"})
-        mock_schedule_broadcast.return_value.set_result(None)
-        mock_get_block_level.return_value.set_result(2)
         mock_gather.return_value.set_result(None)
-        mock_get_blocks.return_value.set_result([("block_id", 1)])
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_set_block_level.assert_called_once_with("block_id", 3)
         mock_schedule_broadcast.assert_called_once_with("block_id")
@@ -350,17 +308,16 @@ class BroadcastProcessorTests(unittest.TestCase):
     @patch("dragonchain.broadcast_processor.broadcast_processor.needed_verifications", return_value=0)
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_receieved_verifications_for_block_and_level_async",
-        return_value=asyncio.Future(),
+        return_value={"verification"},
     )
     @patch("dragonchain.broadcast_processor.broadcast_processor.make_broadcast_futures")
     @patch("dragonchain.broadcast_processor.broadcast_processor.chain_id_set_from_matchmaking_claim", return_value={"chain_id"})
-    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=asyncio.Future())
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=5)
     @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.gather", return_value=asyncio.Future())
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_blocks_to_process_for_broadcast_async",
-        return_value=asyncio.Future(),
+        return_value=[("block_id", 1)],
     )
-    @async_test
     async def test_process_blocks_removes_l5_block_with_enough_verifications(
         self,
         mock_get_blocks,
@@ -373,11 +330,8 @@ class BroadcastProcessorTests(unittest.TestCase):
         mock_remove_block,
         mock_claim_check,
     ):
-        mock_get_verifications.return_value.set_result({"verification"})
-        mock_remove_block.return_value.set_result(None)
-        mock_get_block_level.return_value.set_result(5)
         mock_gather.return_value.set_result(None)
-        mock_get_blocks.return_value.set_result([("block_id", 1)])
+        mock_remove_block.return_value.set_result(None)
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_remove_block.assert_called_once_with("block_id")
 
@@ -386,20 +340,17 @@ class BroadcastProcessorTests(unittest.TestCase):
     @patch("dragonchain.broadcast_processor.broadcast_processor.needed_verifications", return_value=3)
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_receieved_verifications_for_block_and_level_async",
-        return_value=asyncio.Future(),
+        return_value={"verification"},
     )
-    @patch(
-        "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async", return_value=asyncio.Future()
-    )
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async")
     @patch("dragonchain.broadcast_processor.broadcast_processor.make_broadcast_futures")
     @patch("dragonchain.broadcast_processor.broadcast_processor.chain_id_set_from_matchmaking_claim", return_value={"chain_id"})
-    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=asyncio.Future())
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=2)
     @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.gather", return_value=asyncio.Future())
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_blocks_to_process_for_broadcast_async",
-        return_value=asyncio.Future(),
+        return_value=[("block_id", 1)],
     )
-    @async_test
     async def test_process_blocks_updates_matchmaking_claim_for_new_chain_verification(
         self,
         mock_get_blocks,
@@ -413,11 +364,7 @@ class BroadcastProcessorTests(unittest.TestCase):
         mock_no_response_node,
         mock_claim_check,
     ):
-        mock_get_verifications.return_value.set_result({"verification"})
-        mock_schedule_broadcast.return_value.set_result(None)
-        mock_get_block_level.return_value.set_result(2)
         mock_gather.return_value.set_result(None)
-        mock_get_blocks.return_value.set_result([("block_id", 1)])
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_no_response_node.assert_called_once_with("block_id", 2, "chain_id")
 
@@ -430,20 +377,17 @@ class BroadcastProcessorTests(unittest.TestCase):
     @patch("dragonchain.broadcast_processor.broadcast_processor.needed_verifications", return_value=3)
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_receieved_verifications_for_block_and_level_async",
-        return_value=asyncio.Future(),
+        return_value={"verification"},
     )
-    @patch(
-        "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async", return_value=asyncio.Future()
-    )
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async")
     @patch("dragonchain.broadcast_processor.broadcast_processor.make_broadcast_futures")
     @patch("dragonchain.broadcast_processor.broadcast_processor.chain_id_set_from_matchmaking_claim", return_value={"chain_id"})
-    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=asyncio.Future())
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=2)
     @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.gather", return_value=asyncio.Future())
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_blocks_to_process_for_broadcast_async",
-        return_value=asyncio.Future(),
+        return_value=[("block_id", 1)],
     )
-    @async_test
     async def test_process_blocks_makes_broadcast_and_reschedules_block_when_sending_new_requests(
         self,
         mock_get_blocks,
@@ -458,11 +402,7 @@ class BroadcastProcessorTests(unittest.TestCase):
         mock_no_response_node,
         mock_claim_check,
     ):
-        mock_get_verifications.return_value.set_result({"verification"})
-        mock_schedule_broadcast.return_value.set_result(None)
-        mock_get_block_level.return_value.set_result(2)
         mock_gather.return_value.set_result(None)
-        mock_get_blocks.return_value.set_result([("block_id", 1)])
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_get_futures.assert_called_once_with(None, "block_id", 2, {"chain_id"})
         mock_schedule_broadcast.assert_called_once_with("block_id", 123 + broadcast_processor.BROADCAST_RECEIPT_WAIT_TIME)
@@ -473,20 +413,17 @@ class BroadcastProcessorTests(unittest.TestCase):
     @patch("dragonchain.broadcast_processor.broadcast_processor.needed_verifications", return_value=3)
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_receieved_verifications_for_block_and_level_async",
-        return_value=asyncio.Future(),
+        return_value={"verification"},
     )
-    @patch(
-        "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async", return_value=asyncio.Future()
-    )
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.schedule_block_for_broadcast_async")
     @patch("dragonchain.broadcast_processor.broadcast_processor.make_broadcast_futures", return_value=None)
     @patch("dragonchain.broadcast_processor.broadcast_processor.chain_id_set_from_matchmaking_claim", return_value={"chain_id"})
-    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=asyncio.Future())
+    @patch("dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_current_block_level_async", return_value=2)
     @patch("dragonchain.broadcast_processor.broadcast_processor.asyncio.gather", return_value=asyncio.Future())
     @patch(
         "dragonchain.broadcast_processor.broadcast_processor.broadcast_functions.get_blocks_to_process_for_broadcast_async",
-        return_value=asyncio.Future(),
+        return_value=[("block_id", 1)],
     )
-    @async_test
     async def test_process_blocks_doesnt_reschedule_existing_block_which_failed_had_no_futures(
         self,
         mock_get_blocks,
@@ -500,51 +437,43 @@ class BroadcastProcessorTests(unittest.TestCase):
         mock_no_response_node,
         mock_claim_check,
     ):
-        mock_get_verifications.return_value.set_result({"verification"})
-        mock_schedule_broadcast.return_value.set_result(None)
-        mock_get_block_level.return_value.set_result(2)
         mock_gather.return_value.set_result(None)
-        mock_get_blocks.return_value.set_result([("block_id", 1)])
         await broadcast_processor.process_blocks_for_broadcast(None)
         mock_get_futures.assert_called_once()
         mock_schedule_broadcast.assert_not_called()
 
-    @patch("dragonchain.broadcast_processor.broadcast_processor.VERIFICATION_NOTIFICATION", {"all": ["url1"]})
-    @patch("dragonchain.broadcast_processor.broadcast_functions.get_notification_verifications_for_broadcast_async", return_value=asyncio.Future())
+    @patch(
+        "dragonchain.broadcast_processor.broadcast_functions.get_notification_verifications_for_broadcast_async",
+        return_value={"BLOCK/banana-l2-whatever"},
+    )
     @patch("dragonchain.broadcast_processor.broadcast_processor.sign", return_value="my-signature")
     @patch("dragonchain.broadcast_processor.broadcast_processor.storage.get", return_value=b"location-object-bytes")
     @patch("dragonchain.broadcast_processor.broadcast_processor.keys.get_public_id", return_value="my-public-id")
-    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.srem_async", return_value=asyncio.Future())
-    @async_test
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.srem_async", return_value="OK")
     async def test_process_verification_notification_calls_configured_url(
         self, srem_mock, public_id_mock, storage_get_mock, sign_mock, get_location_mock
     ):
-        get_location_mock.return_value.set_result(["BLOCK/banana-l2-whatever"])
-        mock = MagicMock(return_value=asyncio.Future())
-        mock.return_value.set_result(MagicMock(status=200))
-        fake_session = MagicMock(post=mock)
-        srem_mock.return_value.set_result("OK")
+        broadcast_processor.VERIFICATION_NOTIFICATION = {"all": ["url1"]}
+        fake_session = AsyncMock(post=AsyncMock())
         await broadcast_processor.process_verification_notifications(fake_session)
         fake_session.post.assert_called_once_with(
             data=b"location-object-bytes", headers={"dragonchainId": "my-public-id", "signature": "my-signature"}, timeout=30, url="url1"
         )
         srem_mock.assert_called_once_with("broadcast:notifications", "BLOCK/banana-l2-whatever")
 
-    @patch("dragonchain.broadcast_processor.broadcast_processor.VERIFICATION_NOTIFICATION", {"all": ["url1"]})
-    @patch("dragonchain.broadcast_processor.broadcast_functions.get_notification_verifications_for_broadcast_async", return_value=asyncio.Future())
+    @patch(
+        "dragonchain.broadcast_processor.broadcast_functions.get_notification_verifications_for_broadcast_async",
+        return_value={"BLOCK/banana-l2-whatever"},
+    )
     @patch("dragonchain.broadcast_processor.broadcast_processor.sign", return_value="my-signature")
     @patch("dragonchain.broadcast_processor.broadcast_processor.storage.get", return_value=b"location-object-bytes")
     @patch("dragonchain.broadcast_processor.broadcast_processor.keys.get_public_id", return_value="my-public-id")
-    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.srem_async", return_value=asyncio.Future())
-    @async_test
+    @patch("dragonchain.broadcast_processor.broadcast_functions.redis.srem_async", return_value="OK")
     async def test_process_verification_notification_removes_from_set_when_fail(
         self, srem_mock, public_id_mock, storage_get_mock, sign_mock, get_location_mock
     ):
-        get_location_mock.return_value.set_result(["BLOCK/banana-l2-whatever"])
-        mock = MagicMock(side_effect=Exception("boom"))
-        mock.return_value.set_result(MagicMock(status=200))
-        fake_session = MagicMock(post=mock)
-        srem_mock.return_value.set_result("OK")
+        broadcast_processor.VERIFICATION_NOTIFICATION = {"all": ["url1"]}
+        fake_session = AsyncMock(post=AsyncMock(side_effect=Exception("boom")))
         await broadcast_processor.process_verification_notifications(fake_session)
         fake_session.post.assert_called_once_with(
             data=b"location-object-bytes", headers={"dragonchainId": "my-public-id", "signature": "my-signature"}, timeout=30, url="url1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ aiohttp[speedups]==3.6.2
 aioredis==1.3.1
 base58==1.0.3
 bit==0.6.0
-redisearch==0.8.0
+redisearch==0.8.1
 bnb-tx==0.0.4
 pycoin==0.90.20190728
 mnemonic==0.19


### PR DESCRIPTION
## Description

Python 3.8.1 introduced a breaking change to how async tests are performed, which broke some of our tests when running on python 3.8.1

This PR fixes the tests to be compatible

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] tests are included
- [x] changelog has been modified for the changes
