### PR TITLE
remove tx processor callback checking logs

### DIFF
--- a/dragonchain/lib/callback.py
+++ b/dragonchain/lib/callback.py
@@ -33,9 +33,7 @@ def register_callback(txn_id: str, callback_url: str) -> None:
 
 def fire_if_exists(txn_id: str, transaction_model: transaction_model.TransactionModel) -> None:
     """ Fires a callback with a given payload, then removes from redis"""
-    _log.debug(f"Looking in redis for callback: {CALLBACK_REDIS_KEY} {txn_id}")
     url = redis.hget_sync(CALLBACK_REDIS_KEY, txn_id)
-    _log.debug(f"Found {url}")
     if url is not None:
         try:
             _log.debug(f"POST -> {url}")


### PR DESCRIPTION
## Description

For every transaction that gets processed, two logs are printed, making the transaction processor logs with big blocks pretty unusable. This PR simply removes those logs
