### PR TITLE
Fix l5 receipt processing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,18 @@
 
 ## 4.3.3
 
+- **Bugs:**
+  - Adds Content-Type header to all verification notifications
+  - Add retry logic to catch failed job_processor jobs
+  - Fixes double quote error on VERIFICATION_NOTIFICATION json deployment
+  - Fix bug where an L1 processing a receipt from an L5 could result in dropping some receipts
 - **Packaging:**
-  - Update redisearch, and boto3 dependencies
+  - Update redisearch, base58, and boto3 dependencies
   - Un-pin python to version 3.8.X
   - Update redisearch in helm chart to 1.4.20
 - **Development:**
   - Fix tests for python 3.8.1
   - Use helm 3 (specifically 3.0.2) for dependency container and lint checking
-- **Bugs:**
-  - Adds Content-Type header to all verification notifications
-  - Add retry logic to catch failed job processor jobs
-  - Fixes double quote error on VERIFICATION_NOTIFICATION json.
 
 ## 4.3.2
 

--- a/dragonchain/webserver/lib/dragonnet.py
+++ b/dragonchain/webserver/lib/dragonnet.py
@@ -66,27 +66,36 @@ def process_receipt_v1(block_dto: Dict[str, Any]) -> None:
 
     _log.info(f"Processing receipt for blocks {l1_block_id_set} from L{level_received_from}")
     for l1_block_id in l1_block_id_set:
-        # Check that the chain which sent this receipt is in our claims, and that this L1 block is accepting receipts for this level
-        validations = matchmaking.get_claim_check(l1_block_id)["validations"][f"l{level_received_from}"]
-        if (block_model.dc_id in validations) and broadcast_functions.is_block_accepting_verifications_from_level(l1_block_id, level_received_from):
-            _log.info(f"Verified that block {l1_block_id} was sent. Inserting receipt")
-            storage_location = broadcast_functions.verification_storage_location(l1_block_id, level_received_from, block_model.dc_id)
-            storage.put_object_as_json(storage_location, block_model.export_as_at_rest())
-            # Set new receipt for matchmaking claim check
+        try:
+            # Check that the chain which sent this receipt is in our claims, and that this L1 block is accepting receipts for this level
             try:
-                block_id = block_model.block_id
-                proof = block_model.proof
-                dc_id = block_model.dc_id
-                matchmaking.add_receipt(l1_block_id, level_received_from, dc_id, block_id, proof)
-            except Exception:
-                _log.exception("matchmaking add_receipt failed!")
-            # Update the broadcast system about this receipt
-            broadcast_functions.set_receieved_verification_for_block_from_chain_sync(l1_block_id, level_received_from, block_model.dc_id)
-        else:
-            _log.warning(
-                f"Chain {block_model.dc_id} (level {level_received_from}) returned a receipt that wasn't expected (possibly expired?) for block {l1_block_id}. Rejecting receipt"  # noqa: B950
-            )
-            raise exceptions.NotAcceptingVerifications(f"Not accepting verifications for block {l1_block_id} from {block_model.dc_id}")
+                validations = matchmaking.get_claim_check(l1_block_id)["validations"][f"l{level_received_from}"]
+            except exceptions.NotFound:
+                _log.info(f"Block {l1_block_id} has no claim check. Presumably already closed by another L5. Ignoring receipt for this L1 block.")
+                continue
+            if (block_model.dc_id in validations) and broadcast_functions.is_block_accepting_verifications_from_level(
+                l1_block_id, level_received_from
+            ):
+                _log.info(f"Verified that block {l1_block_id} was sent. Inserting receipt")
+                storage_location = broadcast_functions.verification_storage_location(l1_block_id, level_received_from, block_model.dc_id)
+                storage.put_object_as_json(storage_location, block_model.export_as_at_rest())
+                # Set new receipt for matchmaking claim check
+                try:
+                    block_id = block_model.block_id
+                    proof = block_model.proof
+                    dc_id = block_model.dc_id
+                    matchmaking.add_receipt(l1_block_id, level_received_from, dc_id, block_id, proof)
+                except Exception:
+                    _log.exception("matchmaking add_receipt failed!")
+                # Update the broadcast system about this receipt
+                broadcast_functions.set_receieved_verification_for_block_from_chain_sync(l1_block_id, level_received_from, block_model.dc_id)
+            else:
+                _log.warning(
+                    f"Chain {block_model.dc_id} (level {level_received_from}) returned a receipt that wasn't expected (possibly expired?) for block {l1_block_id}. Rejecting receipt"  # noqa: B950
+                )
+                raise exceptions.NotAcceptingVerifications(f"Not accepting verifications for block {l1_block_id} from {block_model.dc_id}")
+        except Exception:
+            _log.exception(f"Unknown error occurred processing block {l1_block_id}. Skipping receipt for this block.")
 
 
 def enqueue_item_for_verification_v1(content: Dict[str, str], deadline: int) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.11.1
+boto3==1.11.3
 redis==3.3.11
 apscheduler==3.6.3
 jsonpath==0.82
@@ -12,7 +12,7 @@ docker==4.1.0
 gunicorn[gevent]==20.0.4
 aiohttp[speedups]==3.6.2
 aioredis==1.3.1
-base58==1.0.3
+base58==2.0.0
 bit==0.6.0
 redisearch==0.8.3
 bnb-tx==0.0.4


### PR DESCRIPTION
## Description

Fixes #298

Adds generic try/except so that a failure on any individual L1 block in an L5 does not affect the other blocks

Also adds a specific try/catch around fetching the claim check, so if the claim check doesn't exist for a block, it is specifically ignored

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] changelog has been modified for the changes
