### PR TITLE
add interchain transaction publish

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @cheeseandcereal @deanshelton913 @regan-karlewicz

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,5 @@
         "py38"
     ],
     "editor.formatOnSave": true,
-    "restructuredtext.confPath": "${workspaceFolder}/docs",
-    "python.pythonPath": ".venv/bin/python"
+    "restructuredtext.confPath": "${workspaceFolder}/docs"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
         "py38"
     ],
     "editor.formatOnSave": true,
-    "restructuredtext.confPath": "${workspaceFolder}/docs"
+    "restructuredtext.confPath": "${workspaceFolder}/docs",
+    "python.pythonPath": ".venv/bin/python"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Update fwatchdog to 0.18.10 for OpenFaaS smart contracts
 - **Development:**
   - Removed all references about lab chain
+  - Remove codeowners
 
 ## 4.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 - **Feature:**
   - Modify L4 block schema to include chain name in the L4 block header
   - Add new endpoint `DELETE /v1/contract/txn_type/<txn_type>` for deleting smart contracts by transaction type
+  - Add new endpoint `POST /v1/interchains/transaction/publish` for publishing a signed interchain transaction
 - **Packaging:**
-  - Update boto3 dependencies
+  - Update redis, and boto3 dependencies
   - Update redisearch in helm chart to 1.6.7
   - Update fwatchdog to 0.18.10 for OpenFaaS smart contracts
 - **Development:**

--- a/docs/usage/permissioning.md
+++ b/docs/usage/permissioning.md
@@ -110,6 +110,7 @@ custom schema:
 | `interchains`       | `create_interchain`                    | `create`       | default         |
 | `interchains`       | `update_interchain`                    | `update`       | default         |
 | `interchains`       | `create_interchain_transaction`        | `create`       | default         |
+| `interchains`       | `publish_interchain_transaction`       | `create`       | default         |
 | `interchains`       | `list_interchains`                     | `read`         | default         |
 | `interchains`       | `get_interchain`                       | `read`         | default         |
 | `interchains`       | `delete_interchain`                    | `delete`       | default         |

--- a/dragonchain/lib/dto/api_key_model.py
+++ b/dragonchain/lib/dto/api_key_model.py
@@ -86,6 +86,7 @@ ENDPOINT_MAP = {
     "create_interchain": _check_default_endpoint_permission,
     "update_interchain": _check_default_endpoint_permission,
     "create_interchain_transaction": _check_default_endpoint_permission,
+    "publish_interchain_transaction": _check_default_endpoint_permission,
     "list_interchains": _check_default_endpoint_permission,
     "get_interchain": _check_default_endpoint_permission,
     "delete_interchain": _check_default_endpoint_permission,

--- a/dragonchain/lib/dto/bnb_utest.py
+++ b/dragonchain/lib/dto/bnb_utest.py
@@ -112,7 +112,7 @@ class TestBinanceMethods(unittest.TestCase):
         self.assertEqual(response, "ZmFrZV9lbmNvZGVkX3R4bg==")
         mock_encode.assert_called_once()
 
-    def test_publish_transaction(self):
+    def test_publish_l5_transaction(self):
         fake_response = requests.Response()
         fake_response._content = b'{"result": {"hash": "BOGUS_RESULT_HASH"}}'
         self.client._build_transaction_msg = MagicMock(return_value={"built_tx": "fake"})
@@ -121,7 +121,7 @@ class TestBinanceMethods(unittest.TestCase):
         fake_acct._content = b'{"sequence": 0, "account_number": 12345}'
         self.client._call_node_api = MagicMock(return_value=fake_acct)
         self.client._call_node_rpc = MagicMock(return_value=fake_response)
-        response = self.client._publish_transaction("DC-L5:_fake_L5_block_hash")
+        response = self.client._publish_l5_transaction("DC-L5:_fake_L5_block_hash")
         self.assertEqual(response, "BOGUS_RESULT_HASH")
         self.client._call_node_rpc.assert_called_once_with("broadcast_tx_commit", {"tx": "signed_tx"})
 

--- a/dragonchain/lib/dto/btc.py
+++ b/dragonchain/lib/dto/btc.py
@@ -254,7 +254,17 @@ class BitcoinNetwork(model.InterchainModel):
         """
         return base64.b64encode(self.priv_key.to_bytes()).decode("ascii")
 
-    def _publish_transaction(self, transaction_payload: str) -> str:
+    def publish_transaction(self, signed_transaction: str) -> str:
+        """Publish an already signed transaction to this network
+        Args:
+            signed_transaction: The already signed transaction from self.sign_transaction
+        Returns:
+            The string of the published transaction hash
+        """
+        _log.debug(f"[BTC] Publishing transaction {signed_transaction}")
+        return self._call("sendrawtransaction", signed_transaction)
+
+    def _publish_l5_transaction(self, transaction_payload: str) -> str:
         """Publish a transaction to this network with a certain data payload
         Args:
             transaction_payload: The arbitrary data to send with this transaction
@@ -265,7 +275,7 @@ class BitcoinNetwork(model.InterchainModel):
         # Sign transaction data
         signed_transaction = self.sign_transaction({"data": transaction_payload})
         # Send signed transaction
-        return self._call("sendrawtransaction", signed_transaction)
+        return self.publish_transaction(signed_transaction)
 
     def _calculate_transaction_fee(self) -> int:
         """Get the current satoshi/byte fee estimate

--- a/dragonchain/lib/dto/btc_utest.py
+++ b/dragonchain/lib/dto/btc_utest.py
@@ -60,7 +60,7 @@ class TestBitcoinMethods(unittest.TestCase):
     def test_publish_creates_signs_and_sends(self):
         self.client._call = MagicMock(return_value="MyFakeTransactionHash")
         self.client.sign_transaction = MagicMock(return_value="signed_transaction")
-        response = self.client._publish_transaction("DC-L5:0xhash")
+        response = self.client._publish_l5_transaction("DC-L5:0xhash")
         self.assertEqual(response, "MyFakeTransactionHash")
 
         self.client._call.assert_called_once_with("sendrawtransaction", "signed_transaction")

--- a/dragonchain/lib/dto/eth.py
+++ b/dragonchain/lib/dto/eth.py
@@ -234,7 +234,17 @@ class EthereumNetwork(model.InterchainModel):
         """
         return base64.b64encode(self.priv_key.to_bytes()).decode("ascii")
 
-    def _publish_transaction(self, transaction_payload: str) -> str:
+    def publish_transaction(self, signed_transaction: str) -> str:
+        """Publish an already signed transaction to this network
+        Args:
+            signed_transaction: The already signed transaction from self.sign_transaction
+        Returns:
+            The hex string of the published transaction hash
+        """
+        _log.debug(f"[ETH] Publishing transaction {signed_transaction}")
+        return self.w3.toHex(self.w3.eth.sendRawTransaction(signed_transaction))
+
+    def _publish_l5_transaction(self, transaction_payload: str) -> str:
         """Publish a transaction to this network with a certain data payload
         Args:
             transaction_payload: The arbitrary data to send with this transaction
@@ -251,7 +261,7 @@ class EthereumNetwork(model.InterchainModel):
             }
         )
         # Send signed transaction
-        return self.w3.toHex(self.w3.eth.sendRawTransaction(signed_transaction))
+        return self.publish_transaction(signed_transaction)
 
     def _calculate_transaction_fee(self) -> int:
         """Get the current gas price estimate

--- a/dragonchain/lib/dto/eth_utest.py
+++ b/dragonchain/lib/dto/eth_utest.py
@@ -54,7 +54,7 @@ class TestEthereumMethods(unittest.TestCase):
             return_value=b"\xec>s;\xb6\x8a\xbb?\xfa\x87\xa1+\x03\x9at\x9f\xcc\xafXDn\xee\xed\xa9:\xd0\xd5\x9fQ\x03\x8f\xf2"
         )
 
-        response = self.client._publish_transaction("DC-L5:0xhash")
+        response = self.client._publish_l5_transaction("DC-L5:0xhash")
         self.assertEqual(response, "0xec3e733bb68abb3ffa87a12b039a749fccaf58446eeeeda93ad0d59f51038ff2")
 
         self.client.sign_transaction.assert_called_once_with(

--- a/dragonchain/lib/dto/model.py
+++ b/dragonchain/lib/dto/model.py
@@ -71,7 +71,7 @@ class InterchainModel(Model):
         Returns:
             String of the transaction hash (or equivalent) for the posted transaction
         """
-        return self._publish_transaction(f"DC-L5:{l5_block_hash}")
+        return self._publish_l5_transaction(f"DC-L5:{l5_block_hash}")
 
     def is_transaction_confirmed(self, transaction_hash: str) -> bool:
         """Check if a transaction is considered confirmed
@@ -121,8 +121,17 @@ class InterchainModel(Model):
         """
         raise NotImplementedError("This is an abstract method")
 
-    def _publish_transaction(self, payload: str) -> str:
-        """Publish a transaction to this network with a certain data payload
+    def publish_transaction(self, signed_transaction: str) -> str:
+        """Publish an already signed transaction to this network
+        Args:
+            signed_transaction: The already signed transaction from self.sign_transaction
+        Returns:
+            String of created transaction hash (or equivalent)
+        """
+        raise NotImplementedError("This is an abstract method")
+
+    def _publish_l5_transaction(self, payload: str) -> str:
+        """Publish an l5 transaction to this network with a certain data payload (l5 block hash)
         Args:
             transaction_payload: The arbitrary data to send with this transaction
         Returns:

--- a/dragonchain/lib/dto/schema.py
+++ b/dragonchain/lib/dto/schema.py
@@ -577,6 +577,17 @@ set_default_interchain_schema_v1 = {
     "properties": {"version": {"type": "string", "enum": ["1"]}, "blockchain": {"type": "string"}, "name": {"type": "string"}},
 }
 
+publish_interchain_transaction_schema_v1 = {
+    "type": "object",
+    "properties": {
+        "version": {"type": "string", "enum": ["1"]},
+        "blockchain": {"type": "string"},
+        "name": {"type": "string"},
+        "signed_txn": {"type": "string"}
+    },
+    "additionalProperties": False,
+}
+
 # BITCOIN INTERCHAIN #
 
 create_bitcoin_interchain_schema_v1 = {
@@ -778,6 +789,7 @@ permission_document_schema_v1 = {
                                 "create_interchain": default_endpoint_property_schema,
                                 "update_interchain": default_endpoint_property_schema,
                                 "create_interchain_transaction": default_endpoint_property_schema,
+                                "publish_interchain_transaction": default_endpoint_property_schema,
                                 "list_interchains": default_endpoint_property_schema,
                                 "get_interchain": default_endpoint_property_schema,
                                 "delete_interchain": default_endpoint_property_schema,

--- a/dragonchain/lib/dto/schema.py
+++ b/dragonchain/lib/dto/schema.py
@@ -583,7 +583,7 @@ publish_interchain_transaction_schema_v1 = {
         "version": {"type": "string", "enum": ["1"]},
         "blockchain": {"type": "string"},
         "name": {"type": "string"},
-        "signed_txn": {"type": "string"}
+        "signed_txn": {"type": "string"},
     },
     "additionalProperties": False,
 }

--- a/dragonchain/webserver/lib/interchain.py
+++ b/dragonchain/webserver/lib/interchain.py
@@ -182,6 +182,11 @@ def sign_interchain_transaction_v1(blockchain: str, name: str, transaction: Dict
     return {"signed": client.sign_transaction(transaction)}
 
 
+def publish_interchain_transaction_v1(blockchain: str, name: str, signed_transaction: str) -> Dict[str, str]:
+    client = interchain_dao.get_interchain_client(blockchain, name)
+    return {"transaction": client.publish_transaction(signed_transaction)}
+
+
 # Below methods are deprecated and exist for legacy support only. Both methods will return a 404 if not a legacy chain
 
 

--- a/dragonchain/webserver/lib/interchain_utest.py
+++ b/dragonchain/webserver/lib/interchain_utest.py
@@ -68,6 +68,11 @@ class TestInterchain(unittest.TestCase):
         interchain.sign_interchain_transaction_v1("bitcoin", "name", {"some": "data"})
         mock_get_client.return_value.sign_transaction.assert_called_once_with({"some": "data"})
 
+    @patch("dragonchain.lib.dao.interchain_dao.get_interchain_client")
+    def test_publish_interchain_v1(self, mock_get_client):
+        interchain.publish_interchain_transaction_v1("bitcoin", "name", "signed_txn")
+        mock_get_client.return_value.publish_transaction.assert_called_once_with("signed_txn")
+
     @patch("dragonchain.lib.dao.interchain_dao.get_default_interchain_client", return_value="banana")
     @patch("dragonchain.webserver.lib.interchain._get_output_dto_v1", return_value="blah")
     def test_get_default_interchain(self, mock_get_output, mock_get_interchain):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.11.9
-redis==3.3.11
+redis==3.4.1
 apscheduler==3.6.3
 jsonpath==0.82
 Flask==1.1.1


### PR DESCRIPTION
## Description

Adds endpoint for ability to publish (already signed) interchain transactions through dragonchain

##### Checklist

- [x] `./tools.sh full-test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] changelog has been modified for the changes
