### PR TITLE
fix l5 backlog queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
   - Modify L4 block schema to include chain name in the L4 block header
   - Add new endpoint `DELETE /v1/contract/txn_type/<txn_type>` for deleting smart contracts by transaction type
   - Add new endpoint `POST /v1/interchains/transaction/publish` for publishing a signed interchain transaction
+- **Bugs:**
+  - Fix issue where L5 recovery queue would not process when trying to resolve already resolved claim-checks
 - **Packaging:**
-  - Update redis, and boto3 dependencies
+  - Update redis, web3, and boto3 dependencies
   - Update redisearch in helm chart to 1.6.7
   - Update fwatchdog to 0.18.10 for OpenFaaS smart contracts
 - **Development:**

--- a/dragonchain/transaction_processor/level_5_actions.py
+++ b/dragonchain/transaction_processor/level_5_actions.py
@@ -122,6 +122,9 @@ def process_claims_backlog() -> None:
     for claim_check_id in claims_set:
         try:
             matchmaking.resolve_claim_check(claim_check_id)
+        except exceptions.NotFound:
+            # If claim is not found, then this claim is irrelevant and we can safely skip
+            pass
         except Exception:
             _log.exception("Failure to finalize claim in matchmaking.  Skipping the rest of the retry queue.")
             return  # short-circuit and exit early, matchmaking still unreachable

--- a/dragonchain/transaction_processor/level_5_actions_utest.py
+++ b/dragonchain/transaction_processor/level_5_actions_utest.py
@@ -154,6 +154,14 @@ class TestLevelFiveActions(unittest.TestCase):
 
     @patch("dragonchain.lib.database.redis.smembers_sync", return_value={"CLAIMID_1", "CLAIMID_2", "CLAIMID_3"})
     @patch("dragonchain.lib.database.redis.srem_sync", return_value=1)  # successful removal of member from set
+    @patch("dragonchain.lib.matchmaking.resolve_claim_check", side_effect=exceptions.NotFound)
+    def test_process_claims_backlog_works_with_matchmaking_404(self, mock_resolve_claim_check, mock_srem_sync, mock_smembers_sync):
+        level_5_actions.process_claims_backlog()
+        self.assertEqual(mock_resolve_claim_check.call_count, 3)
+        self.assertEqual(mock_srem_sync.call_count, 3)
+
+    @patch("dragonchain.lib.database.redis.smembers_sync", return_value={"CLAIMID_1", "CLAIMID_2", "CLAIMID_3"})
+    @patch("dragonchain.lib.database.redis.srem_sync", return_value=1)  # successful removal of member from set
     @patch("dragonchain.lib.matchmaking.resolve_claim_check", side_effect=exceptions.MatchmakingRetryableError)
     def test_process_claims_backlog_with_matchmaking_still_failing(self, mock_resolve_claim_check, mock_srem_sync, mock_smembers_sync):
         level_5_actions.process_claims_backlog()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==1.1.1
 requests==2.22.0
 fastjsonschema==2.14.2
 secp256k1==0.13.2
-web3==5.4.0
+web3==5.5.0
 kubernetes==10.0.1
 docker==4.1.0
 gunicorn[gevent]==20.0.4


### PR DESCRIPTION
## Description

If an l5 had a recovery backlog queue, it would not tolerate claim checks which have already been resolved by another l5, and will not process any of the backlog.

This PR fixes that by appropriately ignoring 404's from matchmaking.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `./tools.sh full-test` passes
- [x] tests are included
- [x] changelog has been modified for the changes
