### PR TITLE
provide better error when interchain publish fails

### DIFF
--- a/dragonchain/exceptions.py
+++ b/dragonchain/exceptions.py
@@ -151,6 +151,10 @@ class SanityCheckFailure(DragonchainException):
     """Exception raised when sanity check fails"""
 
 
+class InterchainPublishError(DragonchainException):
+    """Exception raised when an interchain publish action fails"""
+
+
 class InterchainConnectionError(DragonchainException):
     """Exception raise when RPC / API call has an error"""
 

--- a/dragonchain/webserver/helpers.py
+++ b/dragonchain/webserver/helpers.py
@@ -113,6 +113,11 @@ def bad_request(exception: Exception) -> dict:
     return format_error("BAD_REQUEST", message)
 
 
+def interchain_publish_error(exception: Exception) -> dict:
+    message = error_reporter.get_exception_message(exception)
+    return format_error("INTERCHAIN_PUBLISH_ERROR", message)
+
+
 def webserver_error_handler(exception: Exception) -> Tuple[str, int, Dict[str, str]]:  # noqa C901
     if isinstance(exception, exceptions.UnauthorizedException):
         status_code = 401
@@ -171,6 +176,9 @@ def webserver_error_handler(exception: Exception) -> Tuple[str, int, Dict[str, s
     elif isinstance(exception, exceptions.OpenFaasException):
         status_code = 500
         surface_error = OPENFAAS_ERROR
+    elif isinstance(exception, exceptions.InterchainPublishError):
+        status_code = 500
+        surface_error = interchain_publish_error(exception)
     else:
         status_code = 500
         surface_error = INTERNAL_SERVER_ERROR

--- a/dragonchain/webserver/lib/interchain.py
+++ b/dragonchain/webserver/lib/interchain.py
@@ -184,7 +184,11 @@ def sign_interchain_transaction_v1(blockchain: str, name: str, transaction: Dict
 
 def publish_interchain_transaction_v1(blockchain: str, name: str, signed_transaction: str) -> Dict[str, str]:
     client = interchain_dao.get_interchain_client(blockchain, name)
-    return {"transaction": client.publish_transaction(signed_transaction)}
+    try:
+        return {"transaction": client.publish_transaction(signed_transaction)}
+    except Exception as e:
+        # Try to surface a usable error for the user if there is a failure
+        raise exceptions.InterchainPublishError(str(e))
 
 
 # Below methods are deprecated and exist for legacy support only. Both methods will return a 404 if not a legacy chain


### PR DESCRIPTION
## Description

This PR attempts to provide a better error for the end user if an interchain transaction publish fails for any reason

##### Checklist

- [x] `./tools.sh full-test` passes
