### PR TITLE
fix transaction query with bad type

### DIFF
--- a/dragonchain/webserver/lib/transactions.py
+++ b/dragonchain/webserver/lib/transactions.py
@@ -71,7 +71,7 @@ def query_transactions_v1(params: Dict[str, Any], parse: bool = True) -> "RSearc
         if error_str.startswith("Syntax error"):
             raise exceptions.BadRequest(error_str)
         # If unknown index, user provided a bad transaction type
-        elif error_str == "Unknown Index name":
+        elif error_str.endswith(": no such index"):
             raise exceptions.BadRequest("Invalid transaction type")
         else:
             raise


### PR DESCRIPTION
## Description

The update to redisearch 1.6.7 changed an error string that we relied upon to determine if a transaction type exists when querying.

This PR fixes that

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `./tools.sh full-test` passes
