### PR TITLE
Remove use of deprecated mypy option

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -18,7 +18,6 @@ ignore_missing_imports=True
 warn_no_return=True
 strict_equality=True
 allow_redefinition=False
-show_none_errors=True
 disallow_untyped_decorators=True
 disallow_subclassing_any=True
 


### PR DESCRIPTION
`show_none_errors` is deprecated, see https://github.com/python/mypy/pull/13507